### PR TITLE
Fix/62 open file bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3418,9 +3418,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -4418,9 +4418,9 @@
       "license": "0BSD"
     },
     "node_modules/tsshogi": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.9.1.tgz",
-      "integrity": "sha512-QXqj3yxqdcj8Rgz3L2FrlOUZffndERZuleOZ9X523jc04AoLJbjdtzTfGMeL0ZdVWjLJjqZKi8mxkOW8QgvrZQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.10.1.tgz",
+      "integrity": "sha512-Dkp7NRMliKnK6oPddm6d+7uPya7y7+PCUIBZVbUPlwd4xRkenf4Lz4sUMiu7F5DrhE2Xqulu7Ye6nuYcULVk4g==",
       "license": "MIT"
     },
     "node_modules/type-check": {

--- a/src/entities/file-tree/api/error.ts
+++ b/src/entities/file-tree/api/error.ts
@@ -15,6 +15,7 @@ export type FsError = {
   message: string;
   path?: string;
   existingPath?: string;
+  cause?: string;
 };
 
 export function asFsError(error: unknown): FsError {

--- a/src/entities/file-tree/model/provider.tsx
+++ b/src/entities/file-tree/model/provider.tsx
@@ -187,15 +187,15 @@ export function FileTreeProvider({ rootDir, children }: Props) {
           "棋譜フォーマットが不明です",
           node.path,
         );
-        pushError(error);
+        dispatch({ type: "kifu_error", payload: error });
         return Err(error);
       }
 
-      dispatch({ type: "loading" });
+      dispatch({ type: "kifu_loading" });
 
       const readRes = await api.readKifu(node);
       if (!readRes.success) {
-        pushError(readRes.error);
+        dispatch({ type: "kifu_error", payload: readRes.error });
         return Err(readRes.error);
       }
 
@@ -211,16 +211,20 @@ export function FileTreeProvider({ rootDir, children }: Props) {
         });
         return Ok(undefined);
       } catch (e) {
-        const error = makeFsError(
-          "invalid_type",
-          e instanceof Error ? e.message : String(e),
-          node.path,
-        );
-        pushError(error);
+        const rawMsg = e instanceof Error ? e.message : String(e);
+        const cause =
+          e instanceof Error && e.stack ? e.stack : rawMsg;
+        const error: FsError = {
+          code: "invalid_type",
+          message: "棋譜の解析に失敗しました。",
+          path: node.path,
+          cause,
+        };
+        dispatch({ type: "kifu_error", payload: error });
         return Err(error);
       }
     },
-    [pushError],
+    [],
   );
 
   const closeActiveKifu = useCallback(() => {
@@ -624,6 +628,10 @@ export function FileTreeProvider({ rootDir, children }: Props) {
     dispatch({ type: "error_cleared" });
   }, []);
 
+  const clearKifuError = useCallback(() => {
+    dispatch({ type: "kifu_error_cleared" });
+  }, []);
+
   const closeConflict = useCallback(() => {
     dispatch({ type: "conflict_closed" });
   }, []);
@@ -657,6 +665,7 @@ export function FileTreeProvider({ rootDir, children }: Props) {
         selectNodeByAbsPath,
         resolveConflictByRename,
         clearError,
+        clearKifuError,
         closeConflict,
       }}
     >

--- a/src/entities/file-tree/model/provider.tsx
+++ b/src/entities/file-tree/model/provider.tsx
@@ -38,6 +38,7 @@ export function FileTreeProvider({ rootDir, children }: Props) {
   const pendingSelectedPathRef = useRef<string | null>(null);
   const selectedNodeRef = useRef(state.selectedNode);
   selectedNodeRef.current = state.selectedNode;
+  const kifuOpenGenerationRef = useRef(0);
 
   const revealNodeInCurrentTree = useCallback(
     (absPath: string) => {
@@ -194,9 +195,13 @@ export function FileTreeProvider({ rootDir, children }: Props) {
       }
 
       const prevSelectedNode = selectedNodeRef.current;
+      const myGeneration = ++kifuOpenGenerationRef.current;
 
       const restoreSelection = () => {
-        dispatch({ type: "node_selected", payload: prevSelectedNode });
+        // このリクエストが最新でなければ、より新しい操作の選択状態を上書きしない
+        if (kifuOpenGenerationRef.current === myGeneration) {
+          dispatch({ type: "node_selected", payload: prevSelectedNode });
+        }
       };
 
       dispatch({ type: "kifu_loading" });

--- a/src/entities/file-tree/model/provider.tsx
+++ b/src/entities/file-tree/model/provider.tsx
@@ -221,9 +221,14 @@ export function FileTreeProvider({ rootDir, children }: Props) {
         return Ok(undefined);
       } catch (e) {
         restoreSelection();
-        const rawMsg = e instanceof Error ? e.message : String(e);
+        // 6: cause には元の例外メッセージのみ。スタックはノイズが多いため除外
+        const rawCause = e instanceof Error ? (e as { cause?: unknown }).cause : undefined;
         const cause =
-          e instanceof Error && e.stack ? e.stack : rawMsg;
+          e instanceof Error
+            ? rawCause instanceof Error
+              ? `${e.message}\n原因: ${rawCause.message}`
+              : e.message
+            : String(e);
         const error: FsError = {
           code: "invalid_type",
           message: "棋譜の解析に失敗しました。",

--- a/src/entities/file-tree/model/provider.tsx
+++ b/src/entities/file-tree/model/provider.tsx
@@ -198,8 +198,13 @@ export function FileTreeProvider({ rootDir, children }: Props) {
       const myGeneration = ++kifuOpenGenerationRef.current;
 
       const restoreSelection = () => {
-        // このリクエストが最新でなければ、より新しい操作の選択状態を上書きしない
-        if (kifuOpenGenerationRef.current === myGeneration) {
+        // 1) このリクエストより新しい openKifuNode が始まっていたらスキップ
+        // 2) openKifuNode 以外の操作（ツリー再読み込み・deleteNode 等）で
+        //    selectedNode が既に別のノードに変わっていてもスキップ
+        if (
+          kifuOpenGenerationRef.current === myGeneration &&
+          selectedNodeRef.current?.path === node.path
+        ) {
           dispatch({ type: "node_selected", payload: prevSelectedNode });
         }
       };

--- a/src/entities/file-tree/model/provider.tsx
+++ b/src/entities/file-tree/model/provider.tsx
@@ -36,6 +36,8 @@ export function FileTreeProvider({ rootDir, children }: Props) {
   const { setRootDir } = useAppConfig();
   const pendingRevealPathRef = useRef<string | null>(null);
   const pendingSelectedPathRef = useRef<string | null>(null);
+  const selectedNodeRef = useRef(state.selectedNode);
+  selectedNodeRef.current = state.selectedNode;
 
   const revealNodeInCurrentTree = useCallback(
     (absPath: string) => {
@@ -191,10 +193,17 @@ export function FileTreeProvider({ rootDir, children }: Props) {
         return Err(error);
       }
 
+      const prevSelectedNode = selectedNodeRef.current;
+
+      const restoreSelection = () => {
+        dispatch({ type: "node_selected", payload: prevSelectedNode });
+      };
+
       dispatch({ type: "kifu_loading" });
 
       const readRes = await api.readKifu(node);
       if (!readRes.success) {
+        restoreSelection();
         dispatch({ type: "kifu_error", payload: readRes.error });
         return Err(readRes.error);
       }
@@ -211,6 +220,7 @@ export function FileTreeProvider({ rootDir, children }: Props) {
         });
         return Ok(undefined);
       } catch (e) {
+        restoreSelection();
         const rawMsg = e instanceof Error ? e.message : String(e);
         const cause =
           e instanceof Error && e.stack ? e.stack : rawMsg;

--- a/src/entities/file-tree/model/provider.tsx
+++ b/src/entities/file-tree/model/provider.tsx
@@ -16,6 +16,7 @@ import {
   parseKifuContentToJKF,
   type KifuCreationOptions,
 } from "@/entities/kifu";
+import { sanitizeJkf } from "@/entities/kifu/lib/sanitizeJkf";
 import {
   findNodeChain,
   isSameOrDescendantPath,
@@ -219,7 +220,7 @@ export function FileTreeProvider({ rootDir, children }: Props) {
       }
 
       try {
-        const jkfData = parseKifuContentToJKF(readRes.data, fmt);
+        const jkfData = sanitizeJkf(parseKifuContentToJKF(readRes.data, fmt));
         dispatch({
           type: "kifu_opened",
           payload: {

--- a/src/entities/file-tree/model/reducer.ts
+++ b/src/entities/file-tree/model/reducer.ts
@@ -8,6 +8,9 @@ export function reducer(
     case "loading":
       return { ...state, isLoading: true, error: null };
 
+    case "kifu_loading":
+      return { ...state, isKifuLoading: true, kifuError: null };
+
     case "tree_loaded":
     case "tree_updated":
       return {
@@ -30,6 +33,8 @@ export function reducer(
         jkfData: action.payload.jkfData,
         kifuFormat: action.payload.format,
         isLoading: false,
+        isKifuLoading: false,
+        kifuError: null,
         error: null,
       };
 
@@ -98,13 +103,16 @@ export function reducer(
       };
 
     case "error":
-      return { ...state, isLoading: false, error: action.payload };
+      return { ...state, isLoading: false, isKifuLoading: false, error: action.payload };
 
     case "error_cleared":
-      return {
-        ...state,
-        error: null,
-      };
+      return { ...state, error: null };
+
+    case "kifu_error":
+      return { ...state, isKifuLoading: false, kifuError: action.payload };
+
+    case "kifu_error_cleared":
+      return { ...state, kifuError: null };
 
     case "conflict_opened":
       return {

--- a/src/entities/file-tree/model/reducer.ts
+++ b/src/entities/file-tree/model/reducer.ts
@@ -9,7 +9,7 @@ export function reducer(
       return { ...state, isLoading: true, error: null };
 
     case "kifu_loading":
-      return { ...state, isKifuLoading: true, kifuError: null };
+      return { ...state, kifuError: null };
 
     case "tree_loaded":
     case "tree_updated":
@@ -33,7 +33,6 @@ export function reducer(
         jkfData: action.payload.jkfData,
         kifuFormat: action.payload.format,
         isLoading: false,
-        isKifuLoading: false,
         kifuError: null,
         error: null,
       };
@@ -103,13 +102,13 @@ export function reducer(
       };
 
     case "error":
-      return { ...state, isLoading: false, isKifuLoading: false, error: action.payload };
+      return { ...state, isLoading: false, error: action.payload };
 
     case "error_cleared":
       return { ...state, error: null };
 
     case "kifu_error":
-      return { ...state, isKifuLoading: false, kifuError: action.payload };
+      return { ...state, kifuError: action.payload };
 
     case "kifu_error_cleared":
       return { ...state, kifuError: null };

--- a/src/entities/file-tree/model/types.ts
+++ b/src/entities/file-tree/model/types.ts
@@ -93,7 +93,6 @@ export type FileTreeState = {
 
   expandedNodes: Set<string>;
   isLoading: boolean;
-  isKifuLoading: boolean;
   menu: MenuState;
   renamingNodeId: string | null;
   creatingDirParentPath: string | null;
@@ -150,7 +149,6 @@ export const initialState: FileTreeState = {
   kifuFormat: null,
   expandedNodes: new Set<string>(),
   isLoading: false,
-  isKifuLoading: false,
   menu: null,
   renamingNodeId: null,
   creatingDirParentPath: null,

--- a/src/entities/file-tree/model/types.ts
+++ b/src/entities/file-tree/model/types.ts
@@ -93,15 +93,18 @@ export type FileTreeState = {
 
   expandedNodes: Set<string>;
   isLoading: boolean;
+  isKifuLoading: boolean;
   menu: MenuState;
   renamingNodeId: string | null;
   creatingDirParentPath: string | null;
   error: FsError | null;
+  kifuError: FsError | null;
   conflict: FileConflictState | null;
 };
 
 export type FileTreeAction =
   | { type: "loading" }
+  | { type: "kifu_loading" }
   | { type: "tree_loaded"; payload: FileTreeNode }
   | { type: "node_selected"; payload: FileTreeNode | null }
   | {
@@ -134,6 +137,8 @@ export type FileTreeAction =
     }
   | { type: "error"; payload: FsError }
   | { type: "error_cleared" }
+  | { type: "kifu_error"; payload: FsError }
+  | { type: "kifu_error_cleared" }
   | { type: "conflict_opened"; payload: FileConflictState }
   | { type: "conflict_closed" };
 
@@ -145,10 +150,12 @@ export const initialState: FileTreeState = {
   kifuFormat: null,
   expandedNodes: new Set<string>(),
   isLoading: false,
+  isKifuLoading: false,
   menu: null,
   renamingNodeId: null,
   creatingDirParentPath: null,
   error: null,
+  kifuError: null,
   conflict: null,
 };
 
@@ -201,6 +208,7 @@ export type FileTreeContextType = FileTreeState & {
   cancelCreateDirectory: () => void;
 
   clearError: () => void;
+  clearKifuError: () => void;
   closeConflict: () => void;
   resolveConflictByRename: (nextName: string) => AsyncResult<void, FsError>;
 

--- a/src/entities/kifu/lib/sanitizeJkf.ts
+++ b/src/entities/kifu/lib/sanitizeJkf.ts
@@ -1,0 +1,25 @@
+import type { JKFData, JKFMove } from "@/entities/kifu/model/jkf";
+
+/**
+ * JKF の forks から空配列・null 先頭エントリを再帰的に除去する。
+ *
+ * JKFPlayer は getReadableForkKifu() で fork[0] に無条件アクセスするため、
+ * 空フォーク [] が存在すると TypeError になる。
+ *
+ * ゲーム本体と viewer が同じ sanitize 済みデータを参照するよう、
+ * データの入り口（parseKifuContentToJKF 直後）で一度だけ適用すること。
+ * これにより forkIndex の整合性が保たれる。
+ */
+export function sanitizeJkfMoves(moves: JKFMove[]): JKFMove[] {
+  return moves.map((m) => {
+    if (!m.forks) return m;
+    const cleanForks = m.forks
+      .filter((fork) => fork.length > 0 && fork[0] != null)
+      .map((fork) => sanitizeJkfMoves(fork));
+    return { ...m, forks: cleanForks.length > 0 ? cleanForks : undefined };
+  });
+}
+
+export function sanitizeJkf(kifu: JKFData): JKFData {
+  return { ...kifu, moves: sanitizeJkfMoves(kifu.moves) };
+}

--- a/src/features/kifu-read-error/index.ts
+++ b/src/features/kifu-read-error/index.ts
@@ -1,0 +1,1 @@
+export { KifuReadErrorDialog } from "./ui/KifuReadErrorDialog";

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
@@ -1,0 +1,229 @@
+@use "@/index.scss" as index;
+
+.kifu-read-error {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  // ── Header ──────────────────────────────────────────────────────────────
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.2rem;
+    min-width: 0;
+  }
+
+  &__iconWrap {
+    flex: 0 0 auto;
+    width: 3.8rem;
+    height: 3.8rem;
+    border-radius: 1.2rem;
+    display: grid;
+    place-items: center;
+    background:
+      linear-gradient(
+        180deg,
+        rgba(index.$color-white, 0.5),
+        rgba(index.$color-white, 0.18)
+      ),
+      rgba(255, 140, 60, 0.12);
+    color: rgba(220, 100, 30, 0.9);
+    border: 1px solid rgba(255, 140, 60, 0.18);
+    box-shadow: 0 0.5rem 1.4rem rgba(0, 0, 0, 0.08);
+  }
+
+  &__headingBlock {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  &__title {
+    font-size: 1.85rem;
+    line-height: 1.28;
+    font-weight: 700;
+    color: index.$color-text-dark-1;
+    letter-spacing: 0.01em;
+  }
+
+  &__file {
+    font-size: 1.18rem;
+    color: rgba(index.$color-text-dark-2, 0.7);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+  }
+
+  &__closeBtn {
+    flex: 0 0 auto;
+    width: 2.8rem;
+    height: 2.8rem;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    border-radius: 0.8rem;
+    color: rgba(index.$color-text-dark-2, 0.55);
+    cursor: pointer;
+    transition: background-color 120ms ease, color 120ms ease;
+
+    &:hover {
+      background: rgba(index.$color-primary-light, 0.08);
+      color: rgba(index.$color-text-dark-2, 0.85);
+    }
+  }
+
+  // ── Reason box (Layer 2) ────────────────────────────────────────────────
+
+  &__reasonBox {
+    border-radius: 1.2rem;
+    border: 1px solid rgba(255, 140, 60, 0.18);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(index.$color-white, 0.5),
+        rgba(index.$color-white, 0.24)
+      ),
+      rgba(255, 200, 120, 0.12);
+    padding: 1.2rem 1.4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+
+  &__reason {
+    font-size: 1.32rem;
+    line-height: 1.65;
+    color: index.$color-text-dark-1;
+    font-weight: 500;
+  }
+
+  &__path {
+    font-size: 1.1rem;
+    color: rgba(index.$color-text-dark-2, 0.6);
+    word-break: break-all;
+    line-height: 1.5;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+  }
+
+  // ── Technical detail (Layer 3) ──────────────────────────────────────────
+
+  &__detail {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  &__detailToggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: none;
+    background: transparent;
+    font-size: 1.15rem;
+    color: rgba(index.$color-text-dark-2, 0.65);
+    cursor: pointer;
+    padding: 0.2rem 0;
+    transition: color 120ms ease;
+
+    &:hover {
+      color: rgba(index.$color-text-dark-2, 0.9);
+    }
+  }
+
+  &__detailBody {
+    background: rgba(index.$color-primary-light, 0.04);
+    border: 1px solid rgba(index.$color-primary-light, 0.1);
+    border-radius: 0.9rem;
+    padding: 1rem 1.2rem;
+    font-size: 1.08rem;
+    line-height: 1.65;
+    color: rgba(index.$color-text-dark-2, 0.8);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    max-height: 16rem;
+    overflow-y: auto;
+  }
+
+  // ── Actions ─────────────────────────────────────────────────────────────
+
+  &__actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+  }
+
+  &__actionsLeft,
+  &__actionsRight {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  &__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    min-width: 9rem;
+    height: 3.6rem;
+    padding: 0 1.2rem;
+    border-radius: 1rem;
+    border: 1px solid transparent;
+    font-size: 1.28rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition:
+      transform 120ms ease,
+      box-shadow 120ms ease,
+      background-color 120ms ease,
+      border-color 120ms ease,
+      opacity 120ms ease;
+
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+    }
+
+    &:active:not(:disabled) {
+      transform: translateY(0) scale(0.985);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(index.$color-secondary-dark, 0.22);
+    }
+
+    &:disabled {
+      opacity: 0.46;
+      cursor: not-allowed;
+      transform: none;
+    }
+
+    &--ghost {
+      background: transparent;
+      border-color: rgba(index.$color-primary-light, 0.14);
+      color: rgba(index.$color-text-dark-2, 0.85);
+    }
+
+    &--primary {
+      background: linear-gradient(
+        180deg,
+        rgba(index.$color-primary-light, 0.96),
+        rgba(index.$color-primary-dark, 0.96)
+      );
+      color: index.$color-text-light-1;
+      box-shadow: 0 0.5rem 1.2rem rgba(44, 54, 57, 0.18);
+    }
+  }
+}

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
-import { AlertTriangle, ChevronDown, ChevronRight, Copy, RefreshCw, X } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, Copy, X } from "lucide-react";
 import Modal from "@/shared/ui/Modal";
 import type { FsError } from "@/entities/file-tree/api/error";
 import "./KifuReadErrorDialog.scss";
 
 type Props = {
   error: FsError | null;
-  onRetry: () => void;
   onDismiss: () => void;
 };
 
@@ -20,7 +19,7 @@ function buildClipboardText(error: FsError): string {
   return lines.join("\n");
 }
 
-export function KifuReadErrorDialog({ error, onRetry, onDismiss }: Props) {
+export function KifuReadErrorDialog({ error, onDismiss }: Props) {
   const [detailOpen, setDetailOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -39,11 +38,6 @@ export function KifuReadErrorDialog({ error, onRetry, onDismiss }: Props) {
     } catch {
       // clipboard unavailable
     }
-  };
-
-  const handleRetry = () => {
-    onDismiss();
-    onRetry();
   };
 
   return (
@@ -116,18 +110,10 @@ export function KifuReadErrorDialog({ error, onRetry, onDismiss }: Props) {
           <div className="kifu-read-error__actionsRight">
             <button
               type="button"
-              className="kifu-read-error__btn kifu-read-error__btn--ghost"
+              className="kifu-read-error__btn kifu-read-error__btn--primary"
               onClick={onDismiss}
             >
               閉じる
-            </button>
-            <button
-              type="button"
-              className="kifu-read-error__btn kifu-read-error__btn--primary"
-              onClick={handleRetry}
-            >
-              <RefreshCw size={13} />
-              再試行
             </button>
           </div>
         </div>

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import { AlertTriangle, ChevronDown, ChevronRight, Copy, RefreshCw, X } from "lucide-react";
+import Modal from "@/shared/ui/Modal";
+import type { FsError } from "@/entities/file-tree/api/error";
+import "./KifuReadErrorDialog.scss";
+
+type Props = {
+  error: FsError | null;
+  onRetry: () => void;
+  onDismiss: () => void;
+};
+
+function buildClipboardText(error: FsError): string {
+  const lines: string[] = [
+    `[棋譜読み込みエラー]`,
+    `メッセージ: ${error.message}`,
+  ];
+  if (error.path) lines.push(`ファイル: ${error.path}`);
+  if (error.cause) lines.push(`\n詳細:\n${error.cause}`);
+  return lines.join("\n");
+}
+
+export function KifuReadErrorDialog({ error, onRetry, onDismiss }: Props) {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  if (!error) return null;
+
+  const hasDetail = !!error.cause;
+  const fileName = error.path
+    ? error.path.split("/").pop() ?? error.path
+    : null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildClipboardText(error));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable
+    }
+  };
+
+  const handleRetry = () => {
+    onDismiss();
+    onRetry();
+  };
+
+  return (
+    <Modal
+      onClose={onDismiss}
+      theme="light"
+      variant="dialog"
+      size="sm"
+      scroll="content"
+      closeOnEsc
+      closeOnOverlay
+    >
+      <div className="kifu-read-error">
+        <header className="kifu-read-error__header">
+          <div className="kifu-read-error__iconWrap" aria-hidden="true">
+            <AlertTriangle size={18} />
+          </div>
+          <div className="kifu-read-error__headingBlock">
+            <h2 className="kifu-read-error__title">棋譜を開けませんでした</h2>
+            {fileName && (
+              <p className="kifu-read-error__file">{fileName}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            className="kifu-read-error__closeBtn"
+            onClick={onDismiss}
+            aria-label="閉じる"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        {/* Layer 2: actionable reason */}
+        <div className="kifu-read-error__reasonBox">
+          <p className="kifu-read-error__reason">{error.message}</p>
+          {error.path && (
+            <p className="kifu-read-error__path">{error.path}</p>
+          )}
+        </div>
+
+        {/* Layer 3: technical detail (collapsible) */}
+        {hasDetail && (
+          <div className="kifu-read-error__detail">
+            <button
+              type="button"
+              className="kifu-read-error__detailToggle"
+              onClick={() => setDetailOpen((v) => !v)}
+            >
+              {detailOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+              技術的な詳細
+            </button>
+            {detailOpen && (
+              <pre className="kifu-read-error__detailBody">{error.cause}</pre>
+            )}
+          </div>
+        )}
+
+        <div className="kifu-read-error__actions">
+          <div className="kifu-read-error__actionsLeft">
+            <button
+              type="button"
+              className="kifu-read-error__btn kifu-read-error__btn--ghost"
+              onClick={() => void handleCopy()}
+            >
+              <Copy size={13} />
+              {copied ? "コピーしました" : "エラーをコピー"}
+            </button>
+          </div>
+          <div className="kifu-read-error__actionsRight">
+            <button
+              type="button"
+              className="kifu-read-error__btn kifu-read-error__btn--ghost"
+              onClick={onDismiss}
+            >
+              閉じる
+            </button>
+            <button
+              type="button"
+              className="kifu-read-error__btn kifu-read-error__btn--primary"
+              onClick={handleRetry}
+            >
+              <RefreshCw size={13} />
+              再試行
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronRight, Copy, X } from "lucide-react";
 import Modal from "@/shared/ui/Modal";
 import type { FsError } from "@/entities/file-tree/api/error";
@@ -23,11 +23,20 @@ export function KifuReadErrorDialog({ error, onDismiss }: Props) {
   const [detailOpen, setDetailOpen] = useState(false);
   const [copied, setCopied] = useState(false);
 
+  // 3: エラーが切り替わったら詳細を閉じてコピー状態をリセット
+  useEffect(() => {
+    if (error) {
+      setDetailOpen(false);
+      setCopied(false);
+    }
+  }, [error]);
+
   if (!error) return null;
 
   const hasDetail = !!error.cause;
+  // 1: Windows の \ にも対応
   const fileName = error.path
-    ? error.path.split("/").pop() ?? error.path
+    ? (error.path.split(/[/\\]/).pop() ?? error.path)
     : null;
 
   const handleCopy = async () => {

--- a/src/pages/AppLayout.tsx
+++ b/src/pages/AppLayout.tsx
@@ -36,7 +36,6 @@ const AppLayout = () => {
     closeConflict,
     resolveConflictByRename,
     clearKifuError,
-    openKifuNode,
   } = useFileTree();
 
   const prevIdRef = useRef<string | null>(null);
@@ -87,9 +86,6 @@ const AppLayout = () => {
       <KifuReadErrorDialog
         error={kifuError}
         onDismiss={clearKifuError}
-        onRetry={() => {
-          if (selectedNode) void openKifuNode(selectedNode);
-        }}
       />
 
       <AppLayoutHeader

--- a/src/pages/AppLayout.tsx
+++ b/src/pages/AppLayout.tsx
@@ -20,6 +20,8 @@ import { usePositionSearch } from "@/entities/search";
 import GameControls from "@/widgets/game-board/ui/GameControls";
 import { useFileTree } from "@/entities/file-tree";
 import FileConflictDialog from "@/features/file-conflict/ui/FileConflictDialog";
+import { KifuReadErrorDialog } from "@/features/kifu-read-error";
+import { AppErrorBoundary } from "@/shared/ui/AppErrorBoundary";
 
 const AppLayout = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
@@ -27,8 +29,15 @@ const AppLayout = () => {
   const { params, updateParams } = useURLParams();
   const rotate = params.pov === "gote";
 
-  const { selectedNode, conflict, closeConflict, resolveConflictByRename } =
-    useFileTree();
+  const {
+    selectedNode,
+    conflict,
+    kifuError,
+    closeConflict,
+    resolveConflictByRename,
+    clearKifuError,
+    openKifuNode,
+  } = useFileTree();
 
   const prevIdRef = useRef<string | null>(null);
   useEffect(() => {
@@ -75,6 +84,13 @@ const AppLayout = () => {
         onCancel={closeConflict}
         onSubmitRename={resolveConflictByRename}
       />
+      <KifuReadErrorDialog
+        error={kifuError}
+        onDismiss={clearKifuError}
+        onRetry={() => {
+          if (selectedNode) void openKifuNode(selectedNode);
+        }}
+      />
 
       <AppLayoutHeader
         toggleSidebar={toggleSidebar}
@@ -107,7 +123,9 @@ const AppLayout = () => {
                     </div>
                   </div>
                   <aside className="workspace__kifuPane">
-                    <KifuStreamList />
+                    <AppErrorBoundary>
+                      <KifuStreamList />
+                    </AppErrorBoundary>
                   </aside>
                 </section>
 

--- a/src/shared/ui/AppErrorBoundary.tsx
+++ b/src/shared/ui/AppErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+};
+
+type State = {
+  error: Error | null;
+};
+
+export class AppErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) {
+        return this.props.fallback(error, this.reset);
+      }
+      return (
+        <div className="app-error-boundary">
+          <p className="app-error-boundary__message">
+            表示中にエラーが発生しました。
+          </p>
+          <button
+            className="app-error-boundary__reset"
+            onClick={this.reset}
+            type="button"
+          >
+            再表示
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/shared/ui/AppErrorBoundary.tsx
+++ b/src/shared/ui/AppErrorBoundary.tsx
@@ -19,6 +19,11 @@ export class AppErrorBoundary extends Component<Props, State> {
     return { error };
   }
 
+  // 5: エラーをコンソールに記録
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[AppErrorBoundary] Uncaught error:", error, info.componentStack);
+  }
+
   reset = () => {
     this.setState({ error: null });
   };
@@ -29,15 +34,33 @@ export class AppErrorBoundary extends Component<Props, State> {
       if (this.props.fallback) {
         return this.props.fallback(error, this.reset);
       }
+      // 4: インラインスタイルで最低限のフォールバック表示を保証
       return (
-        <div className="app-error-boundary">
-          <p className="app-error-boundary__message">
-            表示中にエラーが発生しました。
-          </p>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "1.2rem",
+            padding: "2.4rem",
+            color: "rgba(255,255,255,0.7)",
+            fontSize: "1.3rem",
+          }}
+        >
+          <p>表示中にエラーが発生しました。</p>
           <button
-            className="app-error-boundary__reset"
-            onClick={this.reset}
             type="button"
+            onClick={this.reset}
+            style={{
+              padding: "0.6rem 1.4rem",
+              borderRadius: "0.8rem",
+              border: "1px solid rgba(255,255,255,0.2)",
+              background: "rgba(255,255,255,0.08)",
+              color: "rgba(255,255,255,0.8)",
+              fontSize: "1.2rem",
+              cursor: "pointer",
+            }}
           >
             再表示
           </button>

--- a/src/widgets/kifu-stream/lib/cloneJKF.ts
+++ b/src/widgets/kifu-stream/lib/cloneJKF.ts
@@ -1,14 +1,5 @@
-import type { JKFData, JKFMove } from "@/entities/kifu";
-
-function sanitizeMoves(moves: JKFMove[]): JKFMove[] {
-  return moves.map((m) => {
-    if (!m.forks) return m;
-    const cleanForks = m.forks
-      .filter((fork) => fork.length > 0 && fork[0] != null)
-      .map((fork) => sanitizeMoves(fork));
-    return { ...m, forks: cleanForks.length > 0 ? cleanForks : undefined };
-  });
-}
+import type { JKFData } from "@/entities/kifu";
+import { sanitizeJkf } from "@/entities/kifu/lib/sanitizeJkf";
 
 export function cloneJKF(kifu: JKFData): JKFData {
   const sc = globalThis.structuredClone as
@@ -18,5 +9,7 @@ export function cloneJKF(kifu: JKFData): JKFData {
     typeof sc === "function"
       ? sc(kifu)
       : (JSON.parse(JSON.stringify(kifu)) as JKFData);
-  return { ...cloned, moves: sanitizeMoves(cloned.moves) };
+  // データは parseKifuContentToJKF 時点で sanitize 済み。
+  // ここでも適用することで、テスト等で未 sanitize データが渡された場合の安全網とする。
+  return sanitizeJkf(cloned);
 }

--- a/src/widgets/kifu-stream/lib/cloneJKF.ts
+++ b/src/widgets/kifu-stream/lib/cloneJKF.ts
@@ -1,9 +1,22 @@
-import type { JKFData } from "@/entities/kifu";
+import type { JKFData, JKFMove } from "@/entities/kifu";
+
+function sanitizeMoves(moves: JKFMove[]): JKFMove[] {
+  return moves.map((m) => {
+    if (!m.forks) return m;
+    const cleanForks = m.forks
+      .filter((fork) => fork.length > 0 && fork[0] != null)
+      .map((fork) => sanitizeMoves(fork));
+    return { ...m, forks: cleanForks.length > 0 ? cleanForks : undefined };
+  });
+}
 
 export function cloneJKF(kifu: JKFData): JKFData {
   const sc = globalThis.structuredClone as
     | ((x: JKFData) => JKFData)
     | undefined;
-  if (typeof sc === "function") return sc(kifu);
-  return JSON.parse(JSON.stringify(kifu)) as JKFData;
+  const cloned =
+    typeof sc === "function"
+      ? sc(kifu)
+      : (JSON.parse(JSON.stringify(kifu)) as JKFData);
+  return { ...cloned, moves: sanitizeMoves(cloned.moves) };
 }


### PR DESCRIPTION
  Description:

  ## 背景

  - `forks: [[]]` のような空フォーク配列を JKFPlayer が処理する際に
    `TypeError: undefined is not an object (evaluating 't3.special')` でクラッシュ
  - 棋譜読み込み中にファイルツリーがスピナーに置き換わり消える
  - 読み込み失敗時に何も表示されず、前の盤面状態も失われる
  - 読み込みエラーが React レンダリング全体を巻き込んでホワイトアウト

  ## 変更内容

  ### バグ修正
  - `cloneJKF` に `sanitizeMoves` を追加し、空フォーク配列を JKFPlayer に渡す前に除去

  ### エラー状態の分離
  - 棋譜読み込み用の `kifuError` を一般の `error` と分離
  - `dispatch("loading")` → `dispatch("kifu_loading")` に変更し、棋譜読み込み中もファイルツリーを表示したまま維持
  - 棋譜読み込み失敗時に `selectedNode` を前のノードに戻す（失敗したファイルが選択状態にならない）

  ### エラーUX
  - `KifuReadErrorDialog` を新設（3層エラー表示：タイトル / 理由 / 技術的詳細）
  - エラー内容のクリップボードコピー対応
  - `AppErrorBoundary` を新設し `KifuStreamList` をラップ、レンダリングエラーによるホワイトアウトを防止

  ## 影響範囲

  - `src/entities/file-tree/` — state・reducer・provider
  - `src/features/kifu-read-error/` — 新規
  - `src/shared/ui/AppErrorBoundary` — 新規
  - `src/widgets/kifu-stream/lib/cloneJKF.ts`
  - `src/pages/AppLayout.tsx`
