### PR TITLE
feat(ui): error/toast foundation + modal a11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "sass": "^1.89.0",
         "shogi.js": "^5.4.1",
         "tsshogi": "^1.9.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -5389,6 +5390,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "sass": "^1.89.0",
     "shogi.js": "^5.4.1",
     "tsshogi": "^1.9.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/app/providers/RuntimeProviders.tsx
+++ b/src/app/providers/RuntimeProviders.tsx
@@ -7,23 +7,26 @@ import { PositionSyncProvider } from "./bridges/position-sync";
 import { PositionSearchProvider } from "@/entities/search";
 import { AnalysisBridge } from "./bridges/AnalysisBridge";
 import { StudyPositionsProvider } from "@/entities/study-positions/model/provider";
+import { ToastProvider } from "@/shared/ui/toast";
 
 export function RuntimeProviders({ children }: { children: ReactNode }) {
   return (
-    <FileTreeRootGate>
-      <GamePersistenceGate>
-        <StudyPositionsProvider>
-          <EnginePresetsProvider>
-            <EngineRuntimeBridge>
-              <PositionSyncProvider>
-                <PositionSearchProvider>
-                  <AnalysisBridge>{children}</AnalysisBridge>
-                </PositionSearchProvider>
-              </PositionSyncProvider>
-            </EngineRuntimeBridge>
-          </EnginePresetsProvider>
-        </StudyPositionsProvider>
-      </GamePersistenceGate>
-    </FileTreeRootGate>
+    <ToastProvider>
+      <FileTreeRootGate>
+        <GamePersistenceGate>
+          <StudyPositionsProvider>
+            <EnginePresetsProvider>
+              <EngineRuntimeBridge>
+                <PositionSyncProvider>
+                  <PositionSearchProvider>
+                    <AnalysisBridge>{children}</AnalysisBridge>
+                  </PositionSearchProvider>
+                </PositionSyncProvider>
+              </EngineRuntimeBridge>
+            </EnginePresetsProvider>
+          </StudyPositionsProvider>
+        </GamePersistenceGate>
+      </FileTreeRootGate>
+    </ToastProvider>
   );
 }

--- a/src/app/providers/bridges/position-sync/provider.tsx
+++ b/src/app/providers/bridges/position-sync/provider.tsx
@@ -5,14 +5,31 @@ import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PositionSyncContext } from "./context";
 import { setPositionFromSfen } from "@/entities/engine/api/tauri";
+import { useToast } from "@/shared/ui/toast";
+
+const SYNC_FAIL_TOAST_THRESHOLD = 3;
 
 export function PositionSyncProvider({ children }: { children: React.ReactNode }) {
   const { state: gameState, view: gameView } = useGame();
   const { isReady } = useEngine();
   const { state: presetsState, selectedPresetVersion } = useEnginePresets();
+  const toast = useToast();
   const engineKey = presetsState.selectedPresetId
     ? `${presetsState.selectedPresetId}@${selectedPresetVersion}`
     : "no-engine";
+
+  const failCountRef = useRef(0);
+  const onSyncFail = useCallback(
+    (e: unknown) => {
+      failCountRef.current += 1;
+      console.warn("[position-sync] failed:", e);
+      if (failCountRef.current >= SYNC_FAIL_TOAST_THRESHOLD) {
+        toast.warn("局面の同期に繰り返し失敗しています");
+        failCountRef.current = 0;
+      }
+    },
+    [toast],
+  );
 
   const [syncedEngineKey, setSyncedEngineKey] = useState<string | null>(null);
   const lastEngineKeyRef = useRef<string | null>(engineKey);
@@ -39,7 +56,7 @@ export function PositionSyncProvider({ children }: { children: React.ReactNode }
 
       return gameView.player.shogi.toSFENString(gameView.player.tesuu || 1);
     } catch (error) {
-      console.error("❌ [POSITION] Error getting SFEN:", error);
+      console.error("[position-sync] Error getting SFEN:", error);
       return null;
     }
   }, [gameView.player]);
@@ -89,6 +106,7 @@ export function PositionSyncProvider({ children }: { children: React.ReactNode }
           setSyncedSfen(target);
           setSyncedEngineKey(engineKey);
           setIsPositionSynced(true);
+          failCountRef.current = 0;
         } catch (e) {
           // 万一NotInitializedなら ready待ちへ戻す
           if (isNotInitializedError(e)) {
@@ -130,8 +148,8 @@ export function PositionSyncProvider({ children }: { children: React.ReactNode }
       queuedSfenRef.current = null;
       return;
     }
-    syncPosition().catch(() => {});
-  }, [engineKey, gameState.cursor, syncPosition]);
+    syncPosition().catch(onSyncFail);
+  }, [engineKey, gameState.cursor, syncPosition, onSyncFail]);
 
   useEffect(() => {
     if (!isReady) return;
@@ -141,8 +159,8 @@ export function PositionSyncProvider({ children }: { children: React.ReactNode }
     pendingBeforeReadyRef.current = null;
     // 最新としてキューに積む
     queuedSfenRef.current = pending;
-    syncPosition().catch(() => {});
-  }, [isReady, syncPosition]);
+    syncPosition().catch(onSyncFail);
+  }, [isReady, syncPosition, onSyncFail]);
 
   const currentSfen = getCurrentSfen();
 

--- a/src/entities/engine/model/provider.tsx
+++ b/src/entities/engine/model/provider.tsx
@@ -4,6 +4,7 @@ import type { EngineContextType, EngineRuntimeConfig } from "./types";
 import { equalRuntime } from "../lib/equalRuntime";
 import { engineInitializer } from "../api/initializer";
 import { EngineContext } from "./context";
+import { useToast } from "@/shared/ui/toast";
 
 type Props = {
   children: React.ReactNode;
@@ -12,6 +13,7 @@ type Props = {
 
 export function EngineProvider({ children, desiredRuntime }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const toast = useToast();
 
   const seqRef = useRef(0);
   const lastTriedRef = useRef<EngineRuntimeConfig | null>(null);
@@ -83,7 +85,10 @@ export function EngineProvider({ children, desiredRuntime }: Props) {
     // 設定が無い → 起動中なら止める
     if (!desiredRuntime) {
       if (state.phase === "ready" || state.phase === "initializing" || state.phase === "error") {
-        shutdown().catch(() => {});
+        shutdown().catch((e) => {
+          console.warn("[engine] shutdown failed:", e);
+          toast.warn("エンジンの停止に失敗しました");
+        });
       }
       return;
     }
@@ -92,13 +97,21 @@ export function EngineProvider({ children, desiredRuntime }: Props) {
     if (state.phase === "error") {
       const last = lastTriedRef.current;
       const sameRuntime = last ? equalRuntime(desiredRuntime, last) : false;
-      if (!sameRuntime) initialize().catch(() => {});
+      if (!sameRuntime) {
+        initialize().catch((e) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          toast.error(`エンジンの初期化に失敗しました: ${msg}`);
+        });
+      }
       return;
     }
 
     // idle → 起動
     if (state.phase === "idle") {
-      initialize().catch(() => {});
+      initialize().catch((e) => {
+        const msg = e instanceof Error ? e.message : String(e);
+        toast.error(`エンジンの初期化に失敗しました: ${msg}`);
+      });
       return;
     }
 
@@ -107,10 +120,13 @@ export function EngineProvider({ children, desiredRuntime }: Props) {
       const runtimeChanged = !equalRuntime(desiredRuntime, state.activeRuntime);
 
       if (runtimeChanged) {
-        restart().catch(() => {});
+        restart().catch((e) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          toast.error(`エンジンの再起動に失敗しました: ${msg}`);
+        });
       }
     }
-  }, [desiredRuntime, state.phase, state.activeRuntime, initialize, shutdown, restart]);
+  }, [desiredRuntime, state.phase, state.activeRuntime, initialize, shutdown, restart, toast]);
 
   const value = useMemo<EngineContextType>(
     () => ({

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
@@ -1,10 +1,11 @@
 @use "@/index.scss" as index;
 
-// Local warning palette — keep tones derived from the project base palette
+// Local warning palette — solid, tactile tones derived from the base palette
 $warn-fg: #b25a18;
-$warn-border: rgba($warn-fg, 0.22);
-$warn-bg-top: rgba(index.$color-white, 0.55);
-$warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
+$warn-fg-strong: #8a4413;
+$warn-bg: #fbe7d5;
+$warn-bg-deep: #f5d2b2;
+$warn-border: rgba($warn-fg, 0.32);
 
 .kifu-read-error {
   width: 100%;
@@ -17,22 +18,21 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
 
   &__header {
     display: flex;
-    align-items: flex-start;
-    gap: 1.2rem;
+    align-items: center;
+    gap: 1.1rem;
     min-width: 0;
   }
 
   &__iconWrap {
     flex: 0 0 auto;
-    width: 3.4rem;
-    height: 3.4rem;
+    width: 3.2rem;
+    height: 3.2rem;
     border-radius: 0.8rem;
     display: grid;
     place-items: center;
-    background: linear-gradient(180deg, $warn-bg-top, $warn-bg-bottom);
-    color: $warn-fg;
+    background: $warn-bg-deep;
+    color: $warn-fg-strong;
     border: 1px solid $warn-border;
-    box-shadow: index.$shadow-1;
   }
 
   &__headingBlock {
@@ -40,11 +40,11 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.25rem;
   }
 
   &__title {
-    font-size: 1.6rem;
+    font-size: 1.55rem;
     line-height: 1.3;
     font-weight: 700;
     color: index.$color-text-dark-1;
@@ -53,39 +53,11 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
 
   &__file {
     font-size: 1.15rem;
-    color: rgba(index.$color-text-dark-2, 0.7);
+    color: rgba(index.$color-text-dark-2, 0.78);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
-  }
-
-  &__closeBtn {
-    flex: 0 0 auto;
-    width: 2.8rem;
-    height: 2.8rem;
-    display: grid;
-    place-items: center;
-    border: 1px solid transparent;
-    background: transparent;
-    border-radius: 0.6rem;
-    color: rgba(index.$color-text-dark-2, 0.55);
-    cursor: pointer;
-    transition:
-      background-color 120ms ease,
-      color 120ms ease,
-      border-color 120ms ease,
-      box-shadow 120ms ease;
-
-    &:hover {
-      background: rgba(index.$color-primary-light, 0.08);
-      color: rgba(index.$color-text-dark-2, 0.85);
-    }
-
-    &:focus-visible {
-      outline: none;
-      box-shadow: 0 0 0 3px rgba(index.$color-secondary-dark, 0.22);
-    }
   }
 
   // ── Reason box (Layer 2) ────────────────────────────────────────────────
@@ -93,7 +65,7 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
   &__reasonBox {
     border-radius: 0.8rem;
     border: 1px solid $warn-border;
-    background: linear-gradient(180deg, $warn-bg-top, $warn-bg-bottom);
+    background: $warn-bg;
     padding: 1.1rem 1.3rem;
     display: flex;
     flex-direction: column;
@@ -109,7 +81,7 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
 
   &__path {
     font-size: 1.1rem;
-    color: rgba(index.$color-text-dark-2, 0.6);
+    color: rgba(index.$color-text-dark-2, 0.72);
     word-break: break-all;
     line-height: 1.5;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
@@ -124,13 +96,14 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
   }
 
   &__detailToggle {
-    display: flex;
+    align-self: flex-start;
+    display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
     border: none;
     background: transparent;
     font-size: 1.15rem;
-    color: rgba(index.$color-text-dark-2, 0.65);
+    color: rgba(index.$color-text-dark-2, 0.75);
     cursor: pointer;
     padding: 0.2rem 0.4rem;
     border-radius: 0.4rem;
@@ -139,7 +112,7 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
       box-shadow 120ms ease;
 
     &:hover {
-      color: rgba(index.$color-text-dark-2, 0.9);
+      color: index.$color-text-dark-1;
     }
 
     &:focus-visible {
@@ -149,13 +122,13 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
   }
 
   &__detailBody {
-    background: rgba(index.$color-primary-light, 0.06);
-    border: 1px solid rgba(index.$color-primary-light, 0.12);
+    background: rgba(index.$color-primary-light, 0.08);
+    border: 1px solid rgba(index.$color-primary-light, 0.18);
     border-radius: 0.6rem;
     padding: 1rem 1.2rem;
     font-size: 1.1rem;
     line-height: 1.65;
-    color: rgba(index.$color-text-dark-2, 0.8);
+    color: index.$color-text-dark-2;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
     overflow-x: auto;
     white-space: pre-wrap;
@@ -225,32 +198,29 @@ $warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
 
     &--ghost {
       background: transparent;
-      border-color: rgba(index.$color-primary-light, 0.2);
-      color: rgba(index.$color-text-dark-2, 0.85);
+      border-color: rgba(index.$color-primary-light, 0.28);
+      color: index.$color-text-dark-2;
 
       &:hover:not(:disabled) {
-        background: rgba(index.$color-primary-light, 0.06);
+        background: rgba(index.$color-primary-light, 0.08);
+        border-color: rgba(index.$color-primary-light, 0.4);
       }
     }
 
     &--primary {
-      background: linear-gradient(
-        180deg,
-        rgba(index.$color-primary-light, 0.96),
-        rgba(index.$color-primary-dark, 0.96)
-      );
+      background: index.$color-primary-dark;
       color: index.$color-text-light-1;
-      box-shadow: 0 0.5rem 1.2rem rgba(44, 54, 57, 0.18);
+      box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.18);
 
       &:hover:not(:disabled) {
-        box-shadow: 0 0.6rem 1.4rem rgba(44, 54, 57, 0.24);
+        background: index.$color-primary-light;
+        box-shadow: 0 0.6rem 1.4rem rgba(0, 0, 0, 0.22);
       }
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
     &__btn,
-    &__closeBtn,
     &__detailToggle {
       transition: none;
     }

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
@@ -1,11 +1,17 @@
 @use "@/index.scss" as index;
 
+// Local warning palette — keep tones derived from the project base palette
+$warn-fg: #b25a18;
+$warn-border: rgba($warn-fg, 0.22);
+$warn-bg-top: rgba(index.$color-white, 0.55);
+$warn-bg-bottom: rgba(index.$color-secondary-light, 0.6);
+
 .kifu-read-error {
   width: 100%;
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 1.6rem;
+  gap: 1.4rem;
 
   // ── Header ──────────────────────────────────────────────────────────────
 
@@ -18,17 +24,15 @@
 
   &__iconWrap {
     flex: 0 0 auto;
-    width: 3.8rem;
-    height: 3.8rem;
-    border-radius: 1.2rem;
+    width: 3.4rem;
+    height: 3.4rem;
+    border-radius: 0.8rem;
     display: grid;
     place-items: center;
-    background:
-      linear-gradient(180deg, rgba(index.$color-white, 0.5), rgba(index.$color-white, 0.18)),
-      rgba(255, 140, 60, 0.12);
-    color: rgba(220, 100, 30, 0.9);
-    border: 1px solid rgba(255, 140, 60, 0.18);
-    box-shadow: 0 0.5rem 1.4rem rgba(0, 0, 0, 0.08);
+    background: linear-gradient(180deg, $warn-bg-top, $warn-bg-bottom);
+    color: $warn-fg;
+    border: 1px solid $warn-border;
+    box-shadow: index.$shadow-1;
   }
 
   &__headingBlock {
@@ -40,15 +44,15 @@
   }
 
   &__title {
-    font-size: 1.85rem;
-    line-height: 1.28;
+    font-size: 1.6rem;
+    line-height: 1.3;
     font-weight: 700;
     color: index.$color-text-dark-1;
     letter-spacing: 0.01em;
   }
 
   &__file {
-    font-size: 1.18rem;
+    font-size: 1.15rem;
     color: rgba(index.$color-text-dark-2, 0.7);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -62,38 +66,43 @@
     height: 2.8rem;
     display: grid;
     place-items: center;
-    border: none;
+    border: 1px solid transparent;
     background: transparent;
-    border-radius: 0.8rem;
+    border-radius: 0.6rem;
     color: rgba(index.$color-text-dark-2, 0.55);
     cursor: pointer;
     transition:
       background-color 120ms ease,
-      color 120ms ease;
+      color 120ms ease,
+      border-color 120ms ease,
+      box-shadow 120ms ease;
 
     &:hover {
       background: rgba(index.$color-primary-light, 0.08);
       color: rgba(index.$color-text-dark-2, 0.85);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(index.$color-secondary-dark, 0.22);
     }
   }
 
   // ── Reason box (Layer 2) ────────────────────────────────────────────────
 
   &__reasonBox {
-    border-radius: 1.2rem;
-    border: 1px solid rgba(255, 140, 60, 0.18);
-    background:
-      linear-gradient(180deg, rgba(index.$color-white, 0.5), rgba(index.$color-white, 0.24)),
-      rgba(255, 200, 120, 0.12);
-    padding: 1.2rem 1.4rem;
+    border-radius: 0.8rem;
+    border: 1px solid $warn-border;
+    background: linear-gradient(180deg, $warn-bg-top, $warn-bg-bottom);
+    padding: 1.1rem 1.3rem;
     display: flex;
     flex-direction: column;
-    gap: 0.55rem;
+    gap: 0.5rem;
   }
 
   &__reason {
-    font-size: 1.32rem;
-    line-height: 1.65;
+    font-size: 1.3rem;
+    line-height: 1.6;
     color: index.$color-text-dark-1;
     font-weight: 500;
   }
@@ -111,7 +120,7 @@
   &__detail {
     display: flex;
     flex-direction: column;
-    gap: 0.6rem;
+    gap: 0.5rem;
   }
 
   &__detailToggle {
@@ -123,20 +132,28 @@
     font-size: 1.15rem;
     color: rgba(index.$color-text-dark-2, 0.65);
     cursor: pointer;
-    padding: 0.2rem 0;
-    transition: color 120ms ease;
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.4rem;
+    transition:
+      color 120ms ease,
+      box-shadow 120ms ease;
 
     &:hover {
       color: rgba(index.$color-text-dark-2, 0.9);
     }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 3px rgba(index.$color-secondary-dark, 0.22);
+    }
   }
 
   &__detailBody {
-    background: rgba(index.$color-primary-light, 0.04);
-    border: 1px solid rgba(index.$color-primary-light, 0.1);
-    border-radius: 0.9rem;
+    background: rgba(index.$color-primary-light, 0.06);
+    border: 1px solid rgba(index.$color-primary-light, 0.12);
+    border-radius: 0.6rem;
     padding: 1rem 1.2rem;
-    font-size: 1.08rem;
+    font-size: 1.1rem;
     line-height: 1.65;
     color: rgba(index.$color-text-dark-2, 0.8);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
@@ -155,12 +172,13 @@
     align-items: center;
     gap: 0.8rem;
     flex-wrap: wrap;
+    margin-top: 0.4rem;
   }
 
   &__actionsLeft,
   &__actionsRight {
     display: flex;
-    gap: 0.8rem;
+    gap: 0.6rem;
     align-items: center;
     flex-wrap: wrap;
   }
@@ -169,20 +187,21 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    min-width: 9rem;
-    height: 3.6rem;
+    min-width: 8.4rem;
+    height: 3.2rem;
     padding: 0 1.2rem;
-    border-radius: 1rem;
+    border-radius: 0.6rem;
     border: 1px solid transparent;
-    font-size: 1.28rem;
+    font-size: 1.25rem;
     font-weight: 600;
     letter-spacing: 0.01em;
     cursor: pointer;
     transition:
-      transform 120ms ease,
-      box-shadow 120ms ease,
       background-color 120ms ease,
       border-color 120ms ease,
+      color 120ms ease,
+      transform 120ms ease,
+      box-shadow 120ms ease,
       opacity 120ms ease;
 
     &:hover:not(:disabled) {
@@ -206,8 +225,12 @@
 
     &--ghost {
       background: transparent;
-      border-color: rgba(index.$color-primary-light, 0.14);
+      border-color: rgba(index.$color-primary-light, 0.2);
       color: rgba(index.$color-text-dark-2, 0.85);
+
+      &:hover:not(:disabled) {
+        background: rgba(index.$color-primary-light, 0.06);
+      }
     }
 
     &--primary {
@@ -218,6 +241,23 @@
       );
       color: index.$color-text-light-1;
       box-shadow: 0 0.5rem 1.2rem rgba(44, 54, 57, 0.18);
+
+      &:hover:not(:disabled) {
+        box-shadow: 0 0.6rem 1.4rem rgba(44, 54, 57, 0.24);
+      }
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &__btn,
+    &__closeBtn,
+    &__detailToggle {
+      transition: none;
+    }
+
+    &__btn:hover:not(:disabled),
+    &__btn:active:not(:disabled) {
+      transform: none;
     }
   }
 }

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.scss
@@ -1,11 +1,9 @@
 @use "@/index.scss" as index;
 
-// Local warning palette — solid, tactile tones derived from the base palette
-$warn-fg: #b25a18;
-$warn-fg-strong: #8a4413;
-$warn-bg: #fbe7d5;
-$warn-bg-deep: #f5d2b2;
-$warn-border: rgba($warn-fg, 0.32);
+// Solid warning palette derived from the project base palette
+$warn-fg: #a04a14;
+$warn-bg: #f6e0c8;
+$warn-rule: rgba($warn-fg, 0.45);
 
 .kifu-read-error {
   width: 100%;
@@ -19,20 +17,13 @@ $warn-border: rgba($warn-fg, 0.32);
   &__header {
     display: flex;
     align-items: center;
-    gap: 1.1rem;
+    gap: 0.9rem;
     min-width: 0;
   }
 
-  &__iconWrap {
+  &__icon {
     flex: 0 0 auto;
-    width: 3.2rem;
-    height: 3.2rem;
-    border-radius: 0.8rem;
-    display: grid;
-    place-items: center;
-    background: $warn-bg-deep;
-    color: $warn-fg-strong;
-    border: 1px solid $warn-border;
+    color: $warn-fg;
   }
 
   &__headingBlock {
@@ -40,11 +31,11 @@ $warn-border: rgba($warn-fg, 0.32);
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 0.2rem;
   }
 
   &__title {
-    font-size: 1.55rem;
+    font-size: 1.5rem;
     line-height: 1.3;
     font-weight: 700;
     color: index.$color-text-dark-1;
@@ -52,24 +43,22 @@ $warn-border: rgba($warn-fg, 0.32);
   }
 
   &__file {
-    font-size: 1.15rem;
-    color: rgba(index.$color-text-dark-2, 0.78);
+    font-size: 1.1rem;
+    color: rgba(index.$color-text-dark-2, 0.75);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
   }
 
-  // ── Reason box (Layer 2) ────────────────────────────────────────────────
+  // ── Reason (Layer 2) — left rule accent, no heavy box ───────────────────
 
   &__reasonBox {
-    border-radius: 0.8rem;
-    border: 1px solid $warn-border;
-    background: $warn-bg;
-    padding: 1.1rem 1.3rem;
+    border-left: 2px solid $warn-rule;
+    padding: 0.2rem 0 0.2rem 1.1rem;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.45rem;
   }
 
   &__reason {
@@ -80,8 +69,8 @@ $warn-border: rgba($warn-fg, 0.32);
   }
 
   &__path {
-    font-size: 1.1rem;
-    color: rgba(index.$color-text-dark-2, 0.72);
+    font-size: 1.05rem;
+    color: rgba(index.$color-text-dark-2, 0.7);
     word-break: break-all;
     line-height: 1.5;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
@@ -102,8 +91,8 @@ $warn-border: rgba($warn-fg, 0.32);
     gap: 0.4rem;
     border: none;
     background: transparent;
-    font-size: 1.15rem;
-    color: rgba(index.$color-text-dark-2, 0.75);
+    font-size: 1.1rem;
+    color: rgba(index.$color-text-dark-2, 0.7);
     cursor: pointer;
     padding: 0.2rem 0.4rem;
     border-radius: 0.4rem;
@@ -122,12 +111,12 @@ $warn-border: rgba($warn-fg, 0.32);
   }
 
   &__detailBody {
-    background: rgba(index.$color-primary-light, 0.08);
-    border: 1px solid rgba(index.$color-primary-light, 0.18);
+    background: $warn-bg;
+    border: 1px solid $warn-rule;
     border-radius: 0.6rem;
-    padding: 1rem 1.2rem;
-    font-size: 1.1rem;
-    line-height: 1.65;
+    padding: 0.9rem 1.1rem;
+    font-size: 1.05rem;
+    line-height: 1.6;
     color: index.$color-text-dark-2;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Courier New", monospace;
     overflow-x: auto;
@@ -141,31 +130,20 @@ $warn-border: rgba($warn-fg, 0.32);
 
   &__actions {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    gap: 0.8rem;
-    flex-wrap: wrap;
-    margin-top: 0.4rem;
-  }
-
-  &__actionsLeft,
-  &__actionsRight {
-    display: flex;
-    gap: 0.6rem;
-    align-items: center;
-    flex-wrap: wrap;
+    margin-top: 0.2rem;
   }
 
   &__btn {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    min-width: 8.4rem;
-    height: 3.2rem;
-    padding: 0 1.2rem;
-    border-radius: 0.6rem;
+    height: 3rem;
+    padding: 0 1.1rem;
+    border-radius: 0.5rem;
     border: 1px solid transparent;
-    font-size: 1.25rem;
+    font-size: 1.2rem;
     font-weight: 600;
     letter-spacing: 0.01em;
     cursor: pointer;
@@ -173,17 +151,8 @@ $warn-border: rgba($warn-fg, 0.32);
       background-color 120ms ease,
       border-color 120ms ease,
       color 120ms ease,
-      transform 120ms ease,
       box-shadow 120ms ease,
       opacity 120ms ease;
-
-    &:hover:not(:disabled) {
-      transform: translateY(-1px);
-    }
-
-    &:active:not(:disabled) {
-      transform: translateY(0) scale(0.985);
-    }
 
     &:focus-visible {
       outline: none;
@@ -193,7 +162,6 @@ $warn-border: rgba($warn-fg, 0.32);
     &:disabled {
       opacity: 0.46;
       cursor: not-allowed;
-      transform: none;
     }
 
     &--ghost {
@@ -204,30 +172,8 @@ $warn-border: rgba($warn-fg, 0.32);
       &:hover:not(:disabled) {
         background: rgba(index.$color-primary-light, 0.08);
         border-color: rgba(index.$color-primary-light, 0.4);
+        color: index.$color-text-dark-1;
       }
-    }
-
-    &--primary {
-      background: index.$color-primary-dark;
-      color: index.$color-text-light-1;
-      box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.18);
-
-      &:hover:not(:disabled) {
-        background: index.$color-primary-light;
-        box-shadow: 0 0.6rem 1.4rem rgba(0, 0, 0, 0.22);
-      }
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    &__btn,
-    &__detailToggle {
-      transition: none;
-    }
-
-    &__btn:hover:not(:disabled),
-    &__btn:active:not(:disabled) {
-      transform: none;
     }
   }
 }

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, ChevronDown, ChevronRight, Copy, X } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, Copy } from "lucide-react";
 import Modal from "@/shared/ui/Modal";
 import type { FsError } from "@/entities/file-tree/api/error";
 import "./KifuReadErrorDialog.scss";
@@ -63,14 +63,6 @@ export function KifuReadErrorDialog({ error, onDismiss }: Props) {
             <h2 className="kifu-read-error__title">棋譜を開けませんでした</h2>
             {fileName && <p className="kifu-read-error__file">{fileName}</p>}
           </div>
-          <button
-            type="button"
-            className="kifu-read-error__closeBtn"
-            onClick={onDismiss}
-            aria-label="閉じる"
-          >
-            <X size={16} />
-          </button>
         </header>
 
         {/* Layer 2: actionable reason */}

--- a/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
+++ b/src/features/kifu-read-error/ui/KifuReadErrorDialog.tsx
@@ -56,22 +56,18 @@ export function KifuReadErrorDialog({ error, onDismiss }: Props) {
     >
       <div className="kifu-read-error">
         <header className="kifu-read-error__header">
-          <div className="kifu-read-error__iconWrap" aria-hidden="true">
-            <AlertTriangle size={18} />
-          </div>
+          <AlertTriangle size={18} className="kifu-read-error__icon" aria-hidden="true" />
           <div className="kifu-read-error__headingBlock">
             <h2 className="kifu-read-error__title">棋譜を開けませんでした</h2>
             {fileName && <p className="kifu-read-error__file">{fileName}</p>}
           </div>
         </header>
 
-        {/* Layer 2: actionable reason */}
         <div className="kifu-read-error__reasonBox">
           <p className="kifu-read-error__reason">{error.message}</p>
           {error.path && <p className="kifu-read-error__path">{error.path}</p>}
         </div>
 
-        {/* Layer 3: technical detail (collapsible) */}
         {hasDetail && (
           <div className="kifu-read-error__detail">
             <button
@@ -87,25 +83,14 @@ export function KifuReadErrorDialog({ error, onDismiss }: Props) {
         )}
 
         <div className="kifu-read-error__actions">
-          <div className="kifu-read-error__actionsLeft">
-            <button
-              type="button"
-              className="kifu-read-error__btn kifu-read-error__btn--ghost"
-              onClick={() => void handleCopy()}
-            >
-              <Copy size={13} />
-              {copied ? "コピーしました" : "エラーをコピー"}
-            </button>
-          </div>
-          <div className="kifu-read-error__actionsRight">
-            <button
-              type="button"
-              className="kifu-read-error__btn kifu-read-error__btn--primary"
-              onClick={onDismiss}
-            >
-              閉じる
-            </button>
-          </div>
+          <button
+            type="button"
+            className="kifu-read-error__btn kifu-read-error__btn--ghost"
+            onClick={() => void handleCopy()}
+          >
+            <Copy size={13} />
+            {copied ? "コピーしました" : "エラーをコピー"}
+          </button>
         </div>
       </div>
     </Modal>

--- a/src/shared/lib/errors/AppError.ts
+++ b/src/shared/lib/errors/AppError.ts
@@ -1,0 +1,74 @@
+export type AppErrorCode =
+  | "tauri_invoke_failed"
+  | "fs_error"
+  | "engine_error"
+  | "schema_mismatch"
+  | "unknown";
+
+export interface AppError {
+  code: AppErrorCode;
+  message: string;
+  userMessage: string;
+  cause?: unknown;
+}
+
+export function makeAppError(
+  code: AppErrorCode,
+  message: string,
+  userMessage: string,
+  cause?: unknown,
+): AppError {
+  return { code, message, userMessage, cause };
+}
+
+interface FsErrorShape {
+  code: string;
+  message: string;
+  path?: string;
+}
+
+function isFsErrorShape(value: unknown): value is FsErrorShape {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    "message" in value &&
+    typeof (value as { message: unknown }).message === "string"
+  );
+}
+
+export function fromUnknown(
+  e: unknown,
+  fallbackUserMessage = "予期しないエラーが発生しました",
+): AppError {
+  if (isFsErrorShape(e)) {
+    return {
+      code: "fs_error",
+      message: e.message,
+      userMessage: e.message || fallbackUserMessage,
+      cause: e,
+    };
+  }
+  if (e instanceof Error) {
+    return {
+      code: "unknown",
+      message: e.message,
+      userMessage: fallbackUserMessage,
+      cause: e,
+    };
+  }
+  if (typeof e === "string") {
+    return {
+      code: "tauri_invoke_failed",
+      message: e,
+      userMessage: e || fallbackUserMessage,
+      cause: e,
+    };
+  }
+  return {
+    code: "unknown",
+    message: "non-error thrown",
+    userMessage: fallbackUserMessage,
+    cause: e,
+  };
+}

--- a/src/shared/lib/tauri/safeInvoke.ts
+++ b/src/shared/lib/tauri/safeInvoke.ts
@@ -1,0 +1,42 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { ZodSchema } from "zod";
+import { type AppError, fromUnknown, makeAppError } from "@/shared/lib/errors/AppError";
+
+export type Result<T, E = AppError> = { ok: true; value: T } | { ok: false; error: E };
+
+export interface SafeInvokeOptions<T> {
+  schema?: ZodSchema<T>;
+  userMessage?: string;
+}
+
+export async function safeInvoke<T>(
+  command: string,
+  args?: Record<string, unknown>,
+  options?: SafeInvokeOptions<T>,
+): Promise<Result<T>> {
+  try {
+    const raw = await invoke<unknown>(command, args);
+    if (options?.schema) {
+      const parsed = options.schema.safeParse(raw);
+      if (!parsed.success) {
+        return {
+          ok: false,
+          error: makeAppError(
+            "schema_mismatch",
+            `schema mismatch for ${command}: ${parsed.error.message}`,
+            options.userMessage ?? "サーバーからの応答が不正です",
+            parsed.error,
+          ),
+        };
+      }
+      return { ok: true, value: parsed.data };
+    }
+    return { ok: true, value: raw as T };
+  } catch (e) {
+    return { ok: false, error: fromUnknown(e, options?.userMessage) };
+  }
+}
+
+export function unwrapOr<T>(result: Result<T>, fallback: T): T {
+  return result.ok ? result.value : fallback;
+}

--- a/src/shared/ui/ConfirmDialog.tsx
+++ b/src/shared/ui/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useId, useRef } from "react";
+import { createPortal } from "react-dom";
 import Button from "@/shared/ui/Form/Button";
 import "./ConfirmDialog.scss";
 
@@ -20,11 +22,102 @@ export default function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
-  return (
-    <div className="confirm-dialog-overlay" onClick={onCancel}>
-      <div className="confirm-dialog" onClick={(e) => e.stopPropagation()}>
-        <p className="confirm-dialog__title">{title}</p>
-        {subtitle && <p className="confirm-dialog__sub">{subtitle}</p>}
+  const titleId = useId();
+  const descId = useId();
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  const getActionButtons = (): HTMLButtonElement[] => {
+    const dialog = dialogRef.current;
+    if (!dialog) return [];
+    return Array.from(
+      dialog.querySelectorAll<HTMLButtonElement>(".confirm-dialog__actions button"),
+    );
+  };
+
+  useEffect(() => {
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const buttons = getActionButtons();
+    buttons[0]?.focus();
+
+    return () => {
+      const prev = previouslyFocusedRef.current;
+      if (prev && document.body.contains(prev)) {
+        prev.focus();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.isComposing) return;
+      if (e.key !== "Escape") return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      onCancel();
+    };
+
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [onCancel]);
+
+  const onDialogKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Tab") return;
+
+    const buttons = getActionButtons().filter((b) => !b.disabled);
+    if (buttons.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+    const active = document.activeElement;
+
+    if (e.shiftKey) {
+      if (active === first || !dialogRef.current?.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+
+    if (active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  return createPortal(
+    <div
+      className="confirm-dialog-overlay"
+      onClick={(e) => {
+        if (e.target !== e.currentTarget) return;
+        onCancel();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="confirm-dialog"
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={subtitle ? descId : undefined}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onDialogKeyDown}
+      >
+        <p id={titleId} className="confirm-dialog__title">
+          {title}
+        </p>
+        {subtitle && (
+          <p id={descId} className="confirm-dialog__sub">
+            {subtitle}
+          </p>
+        )}
         <div className="confirm-dialog__actions">
           <Button variant="ghost" onClick={onCancel} disabled={isLoading}>
             {cancelLabel}
@@ -36,6 +129,7 @@ export default function ConfirmDialog({
           </Button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/shared/ui/Modal.tsx
+++ b/src/shared/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import "./Modal.scss";
 import { X } from "lucide-react";
 import { createPortal } from "react-dom";
@@ -23,7 +23,14 @@ interface ModalProps {
   closeOnEsc?: boolean;
   closeOnOverlay?: boolean;
   showCloseButton?: boolean;
+
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
 }
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 function Modal({
   children,
@@ -39,7 +46,14 @@ function Modal({
   closeOnEsc = true,
   closeOnOverlay = true,
   showCloseButton = false,
+
+  ariaLabel,
+  ariaLabelledBy,
+  ariaDescribedBy,
 }: ModalProps) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
   const className = useMemo(() => {
     return [
       "modal",
@@ -67,6 +81,63 @@ function Modal({
     return () => document.removeEventListener("keydown", onKeyDown, true);
   }, [closeOnEsc, onClose]);
 
+  useEffect(() => {
+    previouslyFocusedRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const card = cardRef.current;
+    if (card) {
+      const focusables = card.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      const first = focusables[0];
+      if (first) {
+        first.focus();
+      } else {
+        card.setAttribute("tabindex", "-1");
+        card.focus();
+      }
+    }
+
+    return () => {
+      const prev = previouslyFocusedRef.current;
+      if (prev && document.body.contains(prev)) {
+        prev.focus();
+      }
+    };
+  }, []);
+
+  const onCardKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Tab") return;
+
+    const card = cardRef.current;
+    if (!card) return;
+
+    const focusables = Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (el) => !el.hasAttribute("disabled") && el.tabIndex !== -1,
+    );
+
+    if (focusables.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (e.shiftKey) {
+      if (active === first || !card.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+
+    if (active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
   const root = document.getElementById("modal-root") ?? document.body;
 
   return createPortal(
@@ -79,8 +150,15 @@ function Modal({
         }}
       >
         <div
+          ref={cardRef}
           className={`modal__card modal__card--scroll-${scroll}`}
+          role="dialog"
+          aria-modal="true"
+          aria-label={ariaLabelledBy ? undefined : ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={onCardKeyDown}
         >
           {showCloseButton && (
             <button type="button" className="modal__close" aria-label="閉じる" onClick={onClose}>

--- a/src/shared/ui/floating-note/FloatingNote.tsx
+++ b/src/shared/ui/floating-note/FloatingNote.tsx
@@ -34,6 +34,7 @@ export type FloatingNoteProps = {
   width?: number;
   className?: string;
   children: React.ReactNode;
+  ariaLabel?: string;
 };
 
 function clamp(v: number, lo: number, hi: number) {
@@ -80,6 +81,7 @@ export default function FloatingNote({
   width = 400,
   className,
   children,
+  ariaLabel = "ノート",
 }: FloatingNoteProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const [anchoredPos, setAnchoredPos] = useState<AnchoredPos | null>(null);
@@ -251,7 +253,14 @@ export default function FloatingNote({
   if (!anchoredPos && !geometry) return null;
 
   return createPortal(
-    <div ref={panelRef} className={panelClassName} style={style} role="dialog" aria-modal="false">
+    <div
+      ref={panelRef}
+      className={panelClassName}
+      style={style}
+      role="dialog"
+      aria-modal="false"
+      aria-label={ariaLabel}
+    >
       <div className="floating-note__top-band" aria-hidden="true">
         <div
           className="floating-note__resize floating-note__resize--nw"

--- a/src/shared/ui/toast/Toast.scss
+++ b/src/shared/ui/toast/Toast.scss
@@ -1,0 +1,78 @@
+.toast-container {
+  position: fixed;
+  right: 1.6rem;
+  bottom: 1.6rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  pointer-events: none;
+  max-width: min(36rem, calc(100vw - 3.2rem));
+}
+
+.toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  padding: 1rem 1.2rem;
+  border-radius: 0.8rem;
+  background: rgba(20, 22, 28, 0.96);
+  color: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0.6rem 1.6rem rgba(0, 0, 0, 0.32);
+  font-size: 1.3rem;
+  line-height: 1.5;
+  animation: toast-in 0.18s ease-out;
+
+  &--info {
+    border-left: 3px solid #4aa8ff;
+  }
+  &--success {
+    border-left: 3px solid #4ade80;
+  }
+  &--warn {
+    border-left: 3px solid #f59e0b;
+  }
+  &--error {
+    border-left: 3px solid #ef4444;
+  }
+
+  &__message {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  &__close {
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 1.6rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.4rem;
+    border-radius: 0.4rem;
+
+    &:hover {
+      color: rgba(255, 255, 255, 0.9);
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgba(74, 168, 255, 0.6);
+      outline-offset: 1px;
+    }
+  }
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.6rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/shared/ui/toast/ToastProvider.tsx
+++ b/src/shared/ui/toast/ToastProvider.tsx
@@ -1,0 +1,117 @@
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import type { ToastApi, ToastItem, ToastLevel } from "./types";
+import "./Toast.scss";
+
+const DEFAULT_DURATION_MS: Record<ToastLevel, number> = {
+  info: 3000,
+  success: 3000,
+  warn: 5000,
+  error: 7000,
+};
+
+const MAX_VISIBLE = 5;
+
+export const ToastContext = createContext<ToastApi | null>(null);
+
+function nextId() {
+  return `toast_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([]);
+  const timers = useRef<Map<string, number>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    const t = timers.current.get(id);
+    if (t !== undefined) {
+      window.clearTimeout(t);
+      timers.current.delete(id);
+    }
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }, []);
+
+  const push = useCallback(
+    (level: ToastLevel, message: string, durationMs?: number): string => {
+      const id = nextId();
+      const dur = durationMs ?? DEFAULT_DURATION_MS[level];
+      const item: ToastItem = {
+        id,
+        level,
+        message,
+        durationMs: dur,
+        createdAt: Date.now(),
+      };
+      setItems((prev) => {
+        const next = [...prev, item];
+        return next.length > MAX_VISIBLE ? next.slice(-MAX_VISIBLE) : next;
+      });
+      if (dur > 0) {
+        const t = window.setTimeout(() => dismiss(id), dur);
+        timers.current.set(id, t);
+      }
+      return id;
+    },
+    [dismiss],
+  );
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      info: (m, d) => push("info", m, d),
+      success: (m, d) => push("success", m, d),
+      warn: (m, d) => push("warn", m, d),
+      error: (m, d) => push("error", m, d),
+      dismiss,
+      clear: () => {
+        timers.current.forEach((t) => window.clearTimeout(t));
+        timers.current.clear();
+        setItems([]);
+      },
+    }),
+    [push, dismiss],
+  );
+
+  useEffect(() => {
+    const map = timers.current;
+    return () => {
+      map.forEach((t) => window.clearTimeout(t));
+      map.clear();
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      {createPortal(
+        <div className="toast-container" role="region" aria-label="通知" aria-live="polite">
+          {items.map((i) => (
+            <div
+              key={i.id}
+              className={`toast toast--${i.level}`}
+              role={i.level === "error" || i.level === "warn" ? "alert" : "status"}
+            >
+              <span className="toast__message">{i.message}</span>
+              <button
+                type="button"
+                className="toast__close"
+                aria-label="通知を閉じる"
+                onClick={() => dismiss(i.id)}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </ToastContext.Provider>
+  );
+}

--- a/src/shared/ui/toast/index.ts
+++ b/src/shared/ui/toast/index.ts
@@ -1,0 +1,3 @@
+export { ToastProvider } from "./ToastProvider";
+export { useToast } from "./useToast";
+export type { ToastApi, ToastItem, ToastLevel } from "./types";

--- a/src/shared/ui/toast/types.ts
+++ b/src/shared/ui/toast/types.ts
@@ -1,0 +1,18 @@
+export type ToastLevel = "info" | "success" | "warn" | "error";
+
+export interface ToastItem {
+  id: string;
+  level: ToastLevel;
+  message: string;
+  durationMs: number;
+  createdAt: number;
+}
+
+export interface ToastApi {
+  info: (message: string, durationMs?: number) => string;
+  success: (message: string, durationMs?: number) => string;
+  warn: (message: string, durationMs?: number) => string;
+  error: (message: string, durationMs?: number) => string;
+  dismiss: (id: string) => void;
+  clear: () => void;
+}

--- a/src/shared/ui/toast/useToast.ts
+++ b/src/shared/ui/toast/useToast.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { ToastContext } from "./ToastProvider";
+import type { ToastApi } from "./types";
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used inside <ToastProvider>");
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary

フロントエンドのエラー UX 基盤 + モーダル系の a11y を整える 2 段階の変更。

### Phase 1 (`fc7a0d5`) — エラー/トースト基盤
- `shared/lib/errors/AppError.ts`: `AppError` クラス + `toAppError` で Tauri/未知のエラーを正規化。
- `shared/lib/tauri/safeInvoke.ts`: `invoke` のラッパで失敗時に `AppError` へ変換。
- `shared/ui/toast/*`: `ToastProvider` + `useToast` (`info`/`success`/`warn`/`error`/`dismiss`/`clear`) + 既定 4–6s 表示。
- `app/providers/RuntimeProviders.tsx`: `ToastProvider` を最上位に組み込み。

### Phase 2 (`1ba2fad`) — モーダル系 a11y
- **Modal**: `role="dialog"` + `aria-modal="true"`、`aria-label[ledby]` / `aria-describedby` をオプション props で受ける。マウント時に最初の focusable へフォーカス、アンマウント時に元の要素へフォーカスを戻す。Tab/Shift+Tab で focus trap。
- **ConfirmDialog**: `createPortal(document.body)` でラップ、`role="alertdialog"` + `aria-labelledby`/`describedby` を `useId` で。Cancel ボタンへ既定フォーカス、Escape は document keydown で受けて `stopPropagation`、Tab で Cancel↔Confirm 循環、overlay クリックは `target === currentTarget` で確実にガード。
- **FloatingNote**: `ariaLabel?: string` prop（既定 `"ノート"`）を追加し `aria-label` に反映。非モーダル設計を維持（`aria-modal="false"`）。

### Phase 3 (`1ba2fad`) — `.catch(()=>{})` 一掃
- **EngineProvider**: `shutdown` 失敗 → `toast.warn("エンジンの停止に失敗しました")`、`initialize`/`restart` 失敗 → `toast.error` + 元エラーメッセージ。
- **PositionSyncProvider**: `failCountRef` を導入し、3 連続失敗で一度だけ `toast.warn("局面の同期に繰り返し失敗しています")`、成功時にリセット。`console.error` から絵文字を除去し prefix を `[position-sync]` に統一。

## Test plan

- [x] `npm run build` (TypeScript + Vite) 通過
- [x] `npm run lint` 0 errors（Phase 1 由来の Fast-refresh warning は既知）
- [ ] `npm run tauri dev` で手動確認
  - [ ] エンジンが無い状態 / 不正な設定で `toast.error` が出る
  - [ ] 局面同期失敗を 3 回起こすと `toast.warn` が一度だけ
  - [ ] Modal を開いたとき focus が中に入り、閉じると元の要素に戻る
  - [ ] Modal 内で Tab がカード内をループする
  - [ ] ConfirmDialog で Escape / overlay クリックでキャンセル
  - [ ] スクリーンリーダ（VoiceOver 等）で dialog/alertdialog として認識される