### PR TITLE
fix(ui): prevent player name descenders from being clipped (#71)

### DIFF
--- a/src/widgets/game-board/ui/HandHeader.scss
+++ b/src/widgets/game-board/ui/HandHeader.scss
@@ -45,7 +45,7 @@
   max-width: 100%;
 
   font-size: 1.2rem;
-  line-height: 1.15;
+  line-height: 1.5;
   font-weight: 500;
 
   color: rgba(index.$color-secondary-light, 0.96);


### PR DESCRIPTION
## Summary
- Fix Issue #71: player names (先手/後手) with descender characters (g, y, p, q, j) were being clipped at the bottom.
- Root cause: `.hand-header__name` had `line-height: 1.15` combined with `overflow: hidden`, so the line box wasn't tall enough to contain descenders.
- Bump `line-height` to `1.5`. Baseline alignment with the side symbol (☗/☖) is preserved via the parent's `align-items: baseline`.

## Test plan
- [ ] Open a kifu where either player name contains a descender (e.g. "Bygg", "Yagyu", "yamada") and confirm the bottom of g/y is no longer clipped.
- [ ] Confirm the symbol (☗/☖) and the name still appear baseline-aligned.
- [ ] Confirm long names still ellipsize.

Closes #71