### PR TITLE
feat(engine): Phase 0-1 — preset → AnalysisConfig.mode wiring (#107)

### DIFF
--- a/src-tauri/src/engine/analyzer.rs
+++ b/src-tauri/src/engine/analyzer.rs
@@ -1,5 +1,5 @@
 use crate::engine::utils::{
-    extract_rank, get_depth_of_rank, get_or_create_candidate, map_score_to_evaluation, LogThrottle,
+    extract_rank, get_or_create_candidate, map_score_to_evaluation, LogThrottle,
 };
 
 use super::manager::EngineManager;
@@ -7,7 +7,7 @@ use super::protocol::UsiProtocol;
 use super::types::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex, RwLock};
 use usi::{EngineCommand, GuiCommand, InfoParams, MateParam, ThinkParams};
 
@@ -42,17 +42,6 @@ struct AnalyzerState {
     current_position: Option<String>,
     last_result: Option<AnalysisResult>,
     analysis_count: u64,
-}
-
-enum StreamMode {
-    /// 外部 stop_analysis() を待つ。bestmove は stop 後のみ end とみなす（stale 防止）。
-    Infinite(Arc<AtomicBool>),
-    /// engine 側で自然に終わる（time/byoyomi 切れ、mate 完了 など）。bestmove で end。
-    Finite,
-    /// rank 1 candidate の depth が閾値に達したら stop を送り、bestmove で end。
-    FiniteDepth(u32),
-    /// rank 1 candidate の nodes が閾値に達したら stop を送り、bestmove で end。
-    FiniteNodes(u64),
 }
 
 impl EngineAnalyzer {
@@ -138,127 +127,24 @@ impl EngineAnalyzer {
         Ok(())
     }
 
-    /// 無限解析開始
-    pub async fn start_infinite_analysis(
-        &self,
-    ) -> Result<mpsc::UnboundedReceiver<AnalysisResult>, EngineError> {
-        log::debug!(target: LOGT, "analysis.infinite.start: requested");
-
-        let stop_flag = Arc::new(AtomicBool::new(false));
-        *self.infinite_stop_requested.lock().await = Some(stop_flag.clone());
-
-        // initialized check
-        let manager_guard = self.manager.lock().await;
-        if !manager_guard.is_initialized().await {
-            return Err(EngineError::NotInitialized(
-                "Engine not initialized".to_string(),
-            ));
-        }
-
-        let protocol = manager_guard.protocol()?;
-        drop(manager_guard);
-
-        // channel
-        let (result_tx, result_rx) = mpsc::unbounded_channel();
-        let (raw_tx, raw_rx) = mpsc::unbounded_channel();
-
-        let listener_id = format!(
-            "infinite_analysis_{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        );
-
-        log::debug!(
-            target: LOGT,
-            "analysis.infinite: register_listener id={}",
-            listener_id
-        );
-
-        if let Err(e) = protocol
-            .register_listener(listener_id.clone(), raw_tx)
-            .await
-        {
-            log::error!(
-                target: LOGT,
-                "analysis.infinite: register_listener failed: {:?}",
-                e
-            );
-            return Err(e);
-        }
-
-        log::debug!(target: LOGT, "analysis.infinite: send_command go=infinite");
-        let go_command = GuiCommand::Go(ThinkParams::new().infinite());
-
-        if let Err(e) = protocol.send_command(&go_command).await {
-            log::error!(
-                target: LOGT,
-                "analysis.infinite: send_command failed: {:?}",
-                e
-            );
-            let _ = protocol.remove_listener(&listener_id).await;
-            return Err(e);
-        }
-
-        // 結果処理タスク開始前にログ
-        log::info!(
-            target: LOGT,
-            "analysis.infinite.started listener_id={}",
-            listener_id
-        );
-
-        // 結果処理タスク
-        let state_clone = Arc::clone(&self.state);
-        let protocol_for_task = protocol.clone();
-        let listener_id_for_task = listener_id.clone();
-
-        tokio::spawn(async move {
-            log::debug!(
-                target: LOGT,
-                "analysis.infinite.stream: start listener_id={}",
-                listener_id_for_task
-            );
-            Self::process_analysis_stream(
-                raw_rx,
-                result_tx,
-                state_clone,
-                StreamMode::Infinite(stop_flag),
-                None,
-            )
-            .await;
-
-            protocol_for_task
-                .remove_listener(&listener_id_for_task)
-                .await;
-            log::debug!(
-                target: LOGT,
-                "analysis.infinite.stream: end listener_id={}",
-                listener_id_for_task
-            );
-        });
-
-        Ok(result_rx)
-    }
-
-    /// 設定駆動の解析開始。mode に応じて go コマンドを切り替え、全モード streaming。
+    /// 設定駆動の解析開始。`AnalysisConfig` の variant が停止条件と go コマンド形を決める。
     ///
-    /// - `Infinite`: 既存の `start_infinite_analysis` と同じ意味論
-    /// - `Time`: `byoyomi <ms>` で送る。usi crate 0.6.2 は `go movetime` を ThinkParams で
-    ///   サポートしないため、近似として byoyomi を採用している。raw send 経路が入り次第差し替える。
-    /// - `Depth` / `Nodes`: ceiling として byoyomi 10 分を付け、stream 側で閾値到達時に Stop を送る
-    /// - `Mate`: `mate <ms> | infinite` で送る
-    pub async fn start_with_config(
+    /// - `Infinite`: 外部 `stop_analysis()` を待つ。stop が立つまで bestmove は stale とみなす
+    /// - `Time { seconds }`: `byoyomi <ms>` で送る。usi crate 0.6.2 は `go movetime` を
+    ///   ThinkParams で表現できないため byoyomi で近似している
+    /// - `Depth { plies }` / `Nodes { count }`: ceiling として byoyomi 10 分を付け、
+    ///   rank1 が閾値到達した時点で Stop を送る
+    /// - `Mate`: `go mate infinite` を送る
+    pub async fn start_analysis(
         &self,
         config: AnalysisConfig,
     ) -> Result<mpsc::UnboundedReceiver<AnalysisResult>, EngineError> {
         log::debug!(
             target: LOGT,
-            "analysis.start_with_config: mode={:?}",
-            config.mode
+            "analysis.start: mode={}",
+            config.mode_tag()
         );
 
-        // initialized check & protocol 取得
         let manager_guard = self.manager.lock().await;
         if !manager_guard.is_initialized().await {
             return Err(EngineError::NotInitialized(
@@ -268,51 +154,41 @@ impl EngineAnalyzer {
         let protocol = manager_guard.protocol()?;
         drop(manager_guard);
 
-        // mode 別の stream mode と go コマンドを決定
-        let (stream_mode, go_command) = build_stream_and_go(&config, &self.infinite_stop_requested)
-            .await
-            .ok_or_else(|| EngineError::InvalidState("invalid analysis config".to_string()))?;
+        // Infinite モードのみ外部 stop 用のフラグを登録する
+        let stop_flag = if matches!(config, AnalysisConfig::Infinite) {
+            let flag = Arc::new(AtomicBool::new(false));
+            *self.infinite_stop_requested.lock().await = Some(Arc::clone(&flag));
+            Some(flag)
+        } else {
+            None
+        };
 
-        // channel
+        let go_command = build_go_command(&config);
+
         let (result_tx, result_rx) = mpsc::unbounded_channel();
         let (raw_tx, raw_rx) = mpsc::unbounded_channel();
 
-        let listener_id = format!("analysis_{}_{}", mode_tag(&config.mode), now_nanos());
-
-        log::debug!(
-            target: LOGT,
-            "analysis.start_with_config: register_listener id={}",
-            listener_id
-        );
+        let listener_id = format!("analysis_{}_{}", config.mode_tag(), now_nanos());
 
         if let Err(e) = protocol
             .register_listener(listener_id.clone(), raw_tx)
             .await
         {
-            log::error!(
-                target: LOGT,
-                "analysis.start_with_config: register_listener failed: {:?}",
-                e
-            );
+            log::error!(target: LOGT, "analysis.start: register_listener failed: {:?}", e);
             return Err(e);
         }
 
-        log::debug!(target: LOGT, "analysis.start_with_config: send_command go");
         if let Err(e) = protocol.send_command(&go_command).await {
-            log::error!(
-                target: LOGT,
-                "analysis.start_with_config: send_command failed: {:?}",
-                e
-            );
+            log::error!(target: LOGT, "analysis.start: send_command failed: {:?}", e);
             let _ = protocol.remove_listener(&listener_id).await;
             return Err(e);
         }
 
         log::info!(
             target: LOGT,
-            "analysis.start_with_config.started listener_id={} mode={:?}",
+            "analysis.started listener_id={} mode={}",
             listener_id,
-            config.mode
+            config.mode_tag()
         );
 
         let state_clone = Arc::clone(&self.state);
@@ -320,126 +196,24 @@ impl EngineAnalyzer {
         let listener_id_for_task = listener_id.clone();
 
         tokio::spawn(async move {
-            log::debug!(
-                target: LOGT,
-                "analysis.start_with_config.stream: start listener_id={}",
-                listener_id_for_task
-            );
             Self::process_analysis_stream(
                 raw_rx,
                 result_tx,
                 state_clone,
-                stream_mode,
-                Some(protocol_for_task.clone()),
+                config,
+                stop_flag,
+                protocol_for_task.clone(),
             )
             .await;
 
             protocol_for_task
                 .remove_listener(&listener_id_for_task)
                 .await;
-            log::debug!(
-                target: LOGT,
-                "analysis.start_with_config.stream: end listener_id={}",
-                listener_id_for_task
-            );
         });
 
         Ok(result_rx)
     }
 
-    /// 固定時間解析
-    pub async fn analyze_with_time(
-        &self,
-        time_limit: Duration,
-    ) -> Result<AnalysisResult, EngineError> {
-        let manager_guard = self.manager.lock().await;
-        if !manager_guard.is_initialized().await {
-            return Err(EngineError::NotInitialized(
-                "Engine not initialized".to_string(),
-            ));
-        }
-        let protocol = manager_guard.protocol()?;
-        drop(manager_guard);
-
-        let (raw_tx, mut raw_rx) = mpsc::unbounded_channel();
-
-        let listener_id = format!("timed_analysis_{}", now_nanos());
-
-        protocol
-            .register_listener(listener_id.clone(), raw_tx)
-            .await?;
-
-        // 時間制限付き解析開始
-        let go_command = GuiCommand::Go(ThinkParams::new().byoyomi(time_limit));
-        protocol.send_command(&go_command).await?;
-
-        // 結果収集
-        let result = self.collect_single_result(&mut raw_rx, time_limit).await;
-
-        // クリーンアップ
-        protocol.remove_listener(&listener_id).await;
-
-        let analysis_result = result?;
-
-        // 状態更新
-        {
-            let mut state = self.state.write().await;
-            state.last_result = Some(analysis_result.clone());
-            state.analysis_count += 1;
-        }
-
-        Ok(analysis_result)
-    }
-
-    /// 深度制限解析
-    pub async fn analyze_with_depth(
-        &self,
-        depth_limit: u32,
-    ) -> Result<AnalysisResult, EngineError> {
-        let manager_guard = self.manager.lock().await;
-        if !manager_guard.is_initialized().await {
-            return Err(EngineError::NotInitialized(
-                "Engine not initialized".to_string(),
-            ));
-        }
-        let protocol = manager_guard.protocol()?;
-        drop(manager_guard);
-
-        let (raw_tx, mut raw_rx) = mpsc::unbounded_channel();
-
-        let listener_id = format!("depth_analysis_{}", now_nanos());
-
-        protocol
-            .register_listener(listener_id.clone(), raw_tx)
-            .await?;
-
-        // 深度制限解析 - 時間制限も併用
-        let go_command = GuiCommand::Go(
-            ThinkParams::new().byoyomi(Duration::from_secs(60)), // 最大60秒
-        );
-        protocol.send_command(&go_command).await?;
-
-        // 結果収集（深度チェック付き）
-        let result = self
-            .collect_result_with_depth(&mut raw_rx, depth_limit)
-            .await;
-
-        // クリーンアップ
-        protocol.remove_listener(&listener_id).await;
-
-        let analysis_result = result?;
-
-        // 状態更新
-        {
-            let mut state = self.state.write().await;
-            state.last_result = Some(analysis_result.clone());
-            state.analysis_count += 1;
-        }
-
-        Ok(analysis_result)
-    }
-
-    /// 解析停止
     pub async fn stop_analysis(&self) -> Result<(), EngineError> {
         let manager_guard = self.manager.lock().await;
         if !manager_guard.is_initialized().await {
@@ -475,97 +249,64 @@ impl EngineAnalyzer {
 
     // === 内部ヘルパーメソッド ===
 
-    /// 分析ストリーム処理（infinite / finite / 閾値モード共通）。
-    ///
-    /// 閾値モード（FiniteDepth/FiniteNodes）は rank 1 candidate の値が閾値に達したら
-    /// `protocol` 経由で `Stop` を送る。engine が bestmove を返した時点で stream を閉じる。
+    /// 分析ストリーム処理。`config` の振る舞いメソッドが停止判定と bestmove 処理を担う。
     async fn process_analysis_stream(
         mut raw_rx: mpsc::UnboundedReceiver<EngineCommand>,
         result_tx: mpsc::UnboundedSender<AnalysisResult>,
-        #[allow(unused_variables)] state: Arc<RwLock<AnalyzerState>>,
-        mode: StreamMode,
-        protocol: Option<Arc<UsiProtocol>>,
+        state: Arc<RwLock<AnalyzerState>>,
+        config: AnalysisConfig,
+        stop_flag: Option<Arc<AtomicBool>>,
+        protocol: Arc<UsiProtocol>,
     ) {
-        log::debug!(target: LOGT, "stream: start");
-
         let mut current_result = AnalysisResult::default();
-        let mut processed: u64 = 0;
         let mut stop_sent = false;
-
         let mut stale_bestmove_warn = LogThrottle::new(Duration::from_secs(5));
 
         while let Some(cmd) = raw_rx.recv().await {
-            processed += 1;
-
             match cmd {
                 EngineCommand::Info(info_params) => {
                     Self::process_info_params(&info_params, &mut current_result);
-                    // 更新された結果を送信
                     if result_tx.send(current_result.clone()).is_err() {
-                        log::debug!(target: LOGT, "stream: result channel closed");
                         break;
                     }
 
-                    // 閾値モードは rank 1 を見て stop を一度だけ送る
-                    if !stop_sent {
-                        let reached = match &mode {
-                            StreamMode::FiniteDepth(target) => {
-                                get_depth_of_rank(&current_result, 1).is_some_and(|d| d >= *target)
-                            }
-                            StreamMode::FiniteNodes(target) => current_result
-                                .candidates
-                                .iter()
-                                .find(|c| c.rank == 1)
-                                .and_then(|c| c.nodes)
-                                .is_some_and(|n| n >= *target),
-                            _ => false,
-                        };
-
-                        if reached {
-                            if let Some(p) = &protocol {
-                                if let Err(e) = p.send_command(&GuiCommand::Stop).await {
-                                    log::warn!(
-                                        target: LOGT,
-                                        "stream: threshold stop send failed: {:?}",
-                                        e
-                                    );
-                                }
-                            }
-                            stop_sent = true;
+                    if !stop_sent && config.should_stop_on_info(&current_result) {
+                        if let Err(e) = protocol.send_command(&GuiCommand::Stop).await {
+                            log::warn!(
+                                target: LOGT,
+                                "stream: threshold stop send failed: {:?}",
+                                e
+                            );
                         }
+                        stop_sent = true;
                     }
                 }
                 EngineCommand::Checkmate(checkmate_params) => {
                     Self::process_checkmate(&checkmate_params, &mut current_result);
-
-                    log::info!(target: LOGT, "stream: checkmate received");
                     let _ = result_tx.send(current_result.clone());
                 }
-
-                EngineCommand::BestMove(_) => {
-                    match &mode {
-                        StreamMode::Finite
-                        | StreamMode::FiniteDepth(_)
-                        | StreamMode::FiniteNodes(_) => {
-                            let _ = result_tx.send(current_result.clone());
-                            break;
-                        }
-                        StreamMode::Infinite(stop_flag) => {
-                            // stop してないのに bestmove が来たらstaleの可能性
-                            if !stop_flag.load(Ordering::SeqCst) {
-                                if stale_bestmove_warn.allow() {
-                                    log::warn!(
-                                        target: LOGT,
-                                        "stream: bestmove received without stop request; ignoring (stale?)"
-                                    );
-                                }
-                                continue;
-                            }
-                            let _ = result_tx.send(current_result.clone());
-                            break;
-                        }
+                EngineCommand::BestMove(_) => match config.handle_bestmove() {
+                    BestmoveAction::Finish => {
+                        let _ = result_tx.send(current_result.clone());
+                        break;
                     }
-                }
+                    BestmoveAction::IgnoreUnlessStopped => {
+                        let stopped = stop_flag
+                            .as_ref()
+                            .is_some_and(|f| f.load(Ordering::SeqCst));
+                        if !stopped {
+                            if stale_bestmove_warn.allow() {
+                                log::warn!(
+                                    target: LOGT,
+                                    "stream: bestmove received without stop request; ignoring (stale?)"
+                                );
+                            }
+                            continue;
+                        }
+                        let _ = result_tx.send(current_result.clone());
+                        break;
+                    }
+                },
                 _ => {}
             }
         }
@@ -574,88 +315,6 @@ impl EngineAnalyzer {
             st.last_result = Some(current_result);
             st.analysis_count = st.analysis_count.wrapping_add(1);
         }
-
-        log::debug!(target: LOGT, "stream: end processed={}", processed);
-    }
-
-    /// 単一結果収集
-    async fn collect_single_result(
-        &self,
-        raw_rx: &mut mpsc::UnboundedReceiver<EngineCommand>,
-        timeout: Duration,
-    ) -> Result<AnalysisResult, EngineError> {
-        let mut result = AnalysisResult::default();
-        let start_time = Instant::now();
-
-        while start_time.elapsed() < timeout {
-            match tokio::time::timeout(Duration::from_millis(100), raw_rx.recv()).await {
-                Ok(Some(cmd)) => match cmd {
-                    EngineCommand::Info(info_params) => {
-                        Self::process_info_params(&info_params, &mut result);
-                    }
-                    EngineCommand::Checkmate(checkmate_params) => {
-                        Self::process_checkmate(&checkmate_params, &mut result);
-                    }
-                    EngineCommand::BestMove(_) => {
-                        return Ok(result);
-                    }
-                    _ => {}
-                },
-                Ok(None) => {
-                    return Err(EngineError::CommunicationFailed(
-                        "Channel closed".to_string(),
-                    ));
-                }
-                Err(_) => continue, // タイムアウト継続
-            }
-        }
-
-        Err(EngineError::Timeout("Analysis timeout".to_string()))
-    }
-
-    /// 深度制限付き結果収集
-    async fn collect_result_with_depth(
-        &self,
-        raw_rx: &mut mpsc::UnboundedReceiver<EngineCommand>,
-        target_depth: u32,
-    ) -> Result<AnalysisResult, EngineError> {
-        let mut result = AnalysisResult::default();
-        let timeout = Duration::from_secs(60);
-        let start_time = Instant::now();
-
-        while start_time.elapsed() < timeout {
-            match tokio::time::timeout(Duration::from_millis(100), raw_rx.recv()).await {
-                Ok(Some(cmd)) => {
-                    match cmd {
-                        EngineCommand::Info(info_params) => {
-                            Self::process_info_params(&info_params, &mut result);
-
-                            // 目標深度に達したら停止
-                            if let Some(depth) = get_depth_of_rank(&result, 1) {
-                                if depth >= target_depth {
-                                    self.stop_analysis().await?;
-                                }
-                            }
-                        }
-                        EngineCommand::Checkmate(checkmate_params) => {
-                            Self::process_checkmate(&checkmate_params, &mut result);
-                        }
-                        EngineCommand::BestMove(_) => {
-                            return Ok(result);
-                        }
-                        _ => {}
-                    }
-                }
-                Ok(None) => {
-                    return Err(EngineError::CommunicationFailed(
-                        "Channel closed".to_string(),
-                    ));
-                }
-                Err(_) => continue, // タイムアウト継続
-            }
-        }
-
-        Err(EngineError::Timeout("Analysis timeout".to_string()))
     }
 
     /// InfoParams処理
@@ -713,71 +372,24 @@ impl EngineAnalyzer {
     }
 }
 
-/// AnalysisConfig から StreamMode と USI go コマンドを組み立てる。
+/// `AnalysisConfig` から USI go コマンドを組み立てる。
 ///
-/// Infinite モードのみ stop flag を `infinite_stop_requested` に登録する。
-async fn build_stream_and_go(
-    config: &AnalysisConfig,
-    infinite_stop_requested: &Mutex<Option<Arc<AtomicBool>>>,
-) -> Option<(StreamMode, GuiCommand)> {
-    let stream_mode = match config.mode {
-        AnalysisMode::Infinite => {
-            let flag = Arc::new(AtomicBool::new(false));
-            *infinite_stop_requested.lock().await = Some(Arc::clone(&flag));
-            StreamMode::Infinite(flag)
-        }
-        AnalysisMode::Time | AnalysisMode::Mate => StreamMode::Finite,
-        AnalysisMode::Depth => {
-            let limit = config.depth_limit.unwrap_or(20);
-            StreamMode::FiniteDepth(limit)
-        }
-        AnalysisMode::Nodes => {
-            let limit = config.node_limit.unwrap_or(1_000_000);
-            StreamMode::FiniteNodes(limit)
-        }
-    };
-
-    let go_command = build_go_command(config);
-    Some((stream_mode, go_command))
-}
-
+/// - `Time` は usi 0.6.2 が `go movetime` を ThinkParams で表現できないため byoyomi で近似
+/// - `Depth` / `Nodes` には ceiling として byoyomi 10 分を付け、閾値到達時の Stop で打ち切る
 fn build_go_command(config: &AnalysisConfig) -> GuiCommand {
-    // 閾値モード（depth/nodes）の保険となる長尺 ceiling
     const THRESHOLD_CEILING: Duration = Duration::from_secs(600);
 
-    let params = match config.mode {
-        AnalysisMode::Infinite => ThinkParams::new().infinite(),
-        AnalysisMode::Time => {
-            let d = config
-                .time_limit
-                .as_ref()
-                .map(|d| Duration::new(d.secs, d.nanos))
-                .unwrap_or(Duration::from_secs(10));
-            // NOTE: usi 0.6.2 は `go movetime` を ThinkParams で出せない。
-            // ここでは byoyomi で代用。raw send 経路が来たら差し替える。
-            ThinkParams::new().byoyomi(d)
+    let params = match config {
+        AnalysisConfig::Infinite => ThinkParams::new().infinite(),
+        AnalysisConfig::Time { seconds } => {
+            ThinkParams::new().byoyomi(Duration::from_secs(*seconds))
         }
-        AnalysisMode::Depth | AnalysisMode::Nodes => ThinkParams::new().byoyomi(THRESHOLD_CEILING),
-        AnalysisMode::Mate => {
-            let mate_param = config
-                .time_limit
-                .as_ref()
-                .map(|d| MateParam::Timeout(Duration::new(d.secs, d.nanos)))
-                .unwrap_or(MateParam::Infinite);
-            ThinkParams::new().mate(mate_param)
+        AnalysisConfig::Depth { .. } | AnalysisConfig::Nodes { .. } => {
+            ThinkParams::new().byoyomi(THRESHOLD_CEILING)
         }
+        AnalysisConfig::Mate => ThinkParams::new().mate(MateParam::Infinite),
     };
     GuiCommand::Go(params)
-}
-
-fn mode_tag(mode: &AnalysisMode) -> &'static str {
-    match mode {
-        AnalysisMode::Infinite => "infinite",
-        AnalysisMode::Time => "time",
-        AnalysisMode::Depth => "depth",
-        AnalysisMode::Nodes => "nodes",
-        AnalysisMode::Mate => "mate",
-    }
 }
 
 impl Clone for EngineAnalyzer {

--- a/src-tauri/src/engine/analyzer.rs
+++ b/src-tauri/src/engine/analyzer.rs
@@ -3,12 +3,13 @@ use crate::engine::utils::{
 };
 
 use super::manager::EngineManager;
+use super::protocol::UsiProtocol;
 use super::types::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, Mutex, RwLock};
-use usi::{EngineCommand, GuiCommand, InfoParams, ThinkParams};
+use usi::{EngineCommand, GuiCommand, InfoParams, MateParam, ThinkParams};
 
 const LOGT: &str = "obs_shogi::engine::analyzer";
 
@@ -44,9 +45,14 @@ struct AnalyzerState {
 }
 
 enum StreamMode {
+    /// 外部 stop_analysis() を待つ。bestmove は stop 後のみ end とみなす（stale 防止）。
     Infinite(Arc<AtomicBool>),
-    #[allow(dead_code)]
+    /// engine 側で自然に終わる（time/byoyomi 切れ、mate 完了 など）。bestmove で end。
     Finite,
+    /// rank 1 candidate の depth が閾値に達したら stop を送り、bestmove で end。
+    FiniteDepth(u32),
+    /// rank 1 candidate の nodes が閾値に達したら stop を送り、bestmove で end。
+    FiniteNodes(u64),
 }
 
 impl EngineAnalyzer {
@@ -218,6 +224,7 @@ impl EngineAnalyzer {
                 result_tx,
                 state_clone,
                 StreamMode::Infinite(stop_flag),
+                None,
             )
             .await;
 
@@ -227,6 +234,112 @@ impl EngineAnalyzer {
             log::debug!(
                 target: LOGT,
                 "analysis.infinite.stream: end listener_id={}",
+                listener_id_for_task
+            );
+        });
+
+        Ok(result_rx)
+    }
+
+    /// 設定駆動の解析開始。mode に応じて go コマンドを切り替え、全モード streaming。
+    ///
+    /// - `Infinite`: 既存の `start_infinite_analysis` と同じ意味論
+    /// - `Time`: `byoyomi <ms>` で送る。usi crate 0.6.2 は `go movetime` を ThinkParams で
+    ///   サポートしないため、近似として byoyomi を採用している。raw send 経路が入り次第差し替える。
+    /// - `Depth` / `Nodes`: ceiling として byoyomi 10 分を付け、stream 側で閾値到達時に Stop を送る
+    /// - `Mate`: `mate <ms> | infinite` で送る
+    pub async fn start_with_config(
+        &self,
+        config: AnalysisConfig,
+    ) -> Result<mpsc::UnboundedReceiver<AnalysisResult>, EngineError> {
+        log::debug!(
+            target: LOGT,
+            "analysis.start_with_config: mode={:?}",
+            config.mode
+        );
+
+        // initialized check & protocol 取得
+        let manager_guard = self.manager.lock().await;
+        if !manager_guard.is_initialized().await {
+            return Err(EngineError::NotInitialized(
+                "Engine not initialized".to_string(),
+            ));
+        }
+        let protocol = manager_guard.protocol()?;
+        drop(manager_guard);
+
+        // mode 別の stream mode と go コマンドを決定
+        let (stream_mode, go_command) = build_stream_and_go(&config, &self.infinite_stop_requested)
+            .await
+            .ok_or_else(|| EngineError::InvalidState("invalid analysis config".to_string()))?;
+
+        // channel
+        let (result_tx, result_rx) = mpsc::unbounded_channel();
+        let (raw_tx, raw_rx) = mpsc::unbounded_channel();
+
+        let listener_id = format!("analysis_{}_{}", mode_tag(&config.mode), now_nanos());
+
+        log::debug!(
+            target: LOGT,
+            "analysis.start_with_config: register_listener id={}",
+            listener_id
+        );
+
+        if let Err(e) = protocol
+            .register_listener(listener_id.clone(), raw_tx)
+            .await
+        {
+            log::error!(
+                target: LOGT,
+                "analysis.start_with_config: register_listener failed: {:?}",
+                e
+            );
+            return Err(e);
+        }
+
+        log::debug!(target: LOGT, "analysis.start_with_config: send_command go");
+        if let Err(e) = protocol.send_command(&go_command).await {
+            log::error!(
+                target: LOGT,
+                "analysis.start_with_config: send_command failed: {:?}",
+                e
+            );
+            let _ = protocol.remove_listener(&listener_id).await;
+            return Err(e);
+        }
+
+        log::info!(
+            target: LOGT,
+            "analysis.start_with_config.started listener_id={} mode={:?}",
+            listener_id,
+            config.mode
+        );
+
+        let state_clone = Arc::clone(&self.state);
+        let protocol_for_task = protocol.clone();
+        let listener_id_for_task = listener_id.clone();
+
+        tokio::spawn(async move {
+            log::debug!(
+                target: LOGT,
+                "analysis.start_with_config.stream: start listener_id={}",
+                listener_id_for_task
+            );
+            Self::process_analysis_stream(
+                raw_rx,
+                result_tx,
+                state_clone,
+                stream_mode,
+                Some(protocol_for_task.clone()),
+            )
+            .await;
+
+            protocol_for_task
+                .remove_listener(&listener_id_for_task)
+                .await;
+            log::debug!(
+                target: LOGT,
+                "analysis.start_with_config.stream: end listener_id={}",
                 listener_id_for_task
             );
         });
@@ -362,17 +475,22 @@ impl EngineAnalyzer {
 
     // === 内部ヘルパーメソッド ===
 
-    /// 分析ストリーム処理（無限解析用）
+    /// 分析ストリーム処理（infinite / finite / 閾値モード共通）。
+    ///
+    /// 閾値モード（FiniteDepth/FiniteNodes）は rank 1 candidate の値が閾値に達したら
+    /// `protocol` 経由で `Stop` を送る。engine が bestmove を返した時点で stream を閉じる。
     async fn process_analysis_stream(
         mut raw_rx: mpsc::UnboundedReceiver<EngineCommand>,
         result_tx: mpsc::UnboundedSender<AnalysisResult>,
         #[allow(unused_variables)] state: Arc<RwLock<AnalyzerState>>,
         mode: StreamMode,
+        protocol: Option<Arc<UsiProtocol>>,
     ) {
         log::debug!(target: LOGT, "stream: start");
 
         let mut current_result = AnalysisResult::default();
         let mut processed: u64 = 0;
+        let mut stop_sent = false;
 
         let mut stale_bestmove_warn = LogThrottle::new(Duration::from_secs(5));
 
@@ -387,6 +505,35 @@ impl EngineAnalyzer {
                         log::debug!(target: LOGT, "stream: result channel closed");
                         break;
                     }
+
+                    // 閾値モードは rank 1 を見て stop を一度だけ送る
+                    if !stop_sent {
+                        let reached = match &mode {
+                            StreamMode::FiniteDepth(target) => {
+                                get_depth_of_rank(&current_result, 1).is_some_and(|d| d >= *target)
+                            }
+                            StreamMode::FiniteNodes(target) => current_result
+                                .candidates
+                                .iter()
+                                .find(|c| c.rank == 1)
+                                .and_then(|c| c.nodes)
+                                .is_some_and(|n| n >= *target),
+                            _ => false,
+                        };
+
+                        if reached {
+                            if let Some(p) = &protocol {
+                                if let Err(e) = p.send_command(&GuiCommand::Stop).await {
+                                    log::warn!(
+                                        target: LOGT,
+                                        "stream: threshold stop send failed: {:?}",
+                                        e
+                                    );
+                                }
+                            }
+                            stop_sent = true;
+                        }
+                    }
                 }
                 EngineCommand::Checkmate(checkmate_params) => {
                     Self::process_checkmate(&checkmate_params, &mut current_result);
@@ -397,7 +544,9 @@ impl EngineAnalyzer {
 
                 EngineCommand::BestMove(_) => {
                     match &mode {
-                        StreamMode::Finite => {
+                        StreamMode::Finite
+                        | StreamMode::FiniteDepth(_)
+                        | StreamMode::FiniteNodes(_) => {
                             let _ = result_tx.send(current_result.clone());
                             break;
                         }
@@ -561,6 +710,73 @@ impl EngineAnalyzer {
                 result.mate_sequence = Some(Vec::new());
             }
         }
+    }
+}
+
+/// AnalysisConfig から StreamMode と USI go コマンドを組み立てる。
+///
+/// Infinite モードのみ stop flag を `infinite_stop_requested` に登録する。
+async fn build_stream_and_go(
+    config: &AnalysisConfig,
+    infinite_stop_requested: &Mutex<Option<Arc<AtomicBool>>>,
+) -> Option<(StreamMode, GuiCommand)> {
+    let stream_mode = match config.mode {
+        AnalysisMode::Infinite => {
+            let flag = Arc::new(AtomicBool::new(false));
+            *infinite_stop_requested.lock().await = Some(Arc::clone(&flag));
+            StreamMode::Infinite(flag)
+        }
+        AnalysisMode::Time | AnalysisMode::Mate => StreamMode::Finite,
+        AnalysisMode::Depth => {
+            let limit = config.depth_limit.unwrap_or(20);
+            StreamMode::FiniteDepth(limit)
+        }
+        AnalysisMode::Nodes => {
+            let limit = config.node_limit.unwrap_or(1_000_000);
+            StreamMode::FiniteNodes(limit)
+        }
+    };
+
+    let go_command = build_go_command(config);
+    Some((stream_mode, go_command))
+}
+
+fn build_go_command(config: &AnalysisConfig) -> GuiCommand {
+    // 閾値モード（depth/nodes）の保険となる長尺 ceiling
+    const THRESHOLD_CEILING: Duration = Duration::from_secs(600);
+
+    let params = match config.mode {
+        AnalysisMode::Infinite => ThinkParams::new().infinite(),
+        AnalysisMode::Time => {
+            let d = config
+                .time_limit
+                .as_ref()
+                .map(|d| Duration::new(d.secs, d.nanos))
+                .unwrap_or(Duration::from_secs(10));
+            // NOTE: usi 0.6.2 は `go movetime` を ThinkParams で出せない。
+            // ここでは byoyomi で代用。raw send 経路が来たら差し替える。
+            ThinkParams::new().byoyomi(d)
+        }
+        AnalysisMode::Depth | AnalysisMode::Nodes => ThinkParams::new().byoyomi(THRESHOLD_CEILING),
+        AnalysisMode::Mate => {
+            let mate_param = config
+                .time_limit
+                .as_ref()
+                .map(|d| MateParam::Timeout(Duration::new(d.secs, d.nanos)))
+                .unwrap_or(MateParam::Infinite);
+            ThinkParams::new().mate(mate_param)
+        }
+    };
+    GuiCommand::Go(params)
+}
+
+fn mode_tag(mode: &AnalysisMode) -> &'static str {
+    match mode {
+        AnalysisMode::Infinite => "infinite",
+        AnalysisMode::Time => "time",
+        AnalysisMode::Depth => "depth",
+        AnalysisMode::Nodes => "nodes",
+        AnalysisMode::Mate => "mate",
     }
 }
 

--- a/src-tauri/src/engine/analyzer.rs
+++ b/src-tauri/src/engine/analyzer.rs
@@ -154,12 +154,15 @@ impl EngineAnalyzer {
         let protocol = manager_guard.protocol()?;
         drop(manager_guard);
 
-        // Infinite モードのみ外部 stop 用のフラグを登録する
+        // Infinite モードのみ外部 stop 用のフラグを登録する。
+        // 前回セッションの flag が居座らないよう、非 Infinite では明示的に None に戻す
+        // (M1: 旧 fix — 将来 IgnoreUnlessStopped を使う他モードが増えても破綻しないため)
         let stop_flag = if matches!(config, AnalysisConfig::Infinite) {
             let flag = Arc::new(AtomicBool::new(false));
             *self.infinite_stop_requested.lock().await = Some(Arc::clone(&flag));
             Some(flag)
         } else {
+            *self.infinite_stop_requested.lock().await = None;
             None
         };
 
@@ -291,9 +294,7 @@ impl EngineAnalyzer {
                         break;
                     }
                     BestmoveAction::IgnoreUnlessStopped => {
-                        let stopped = stop_flag
-                            .as_ref()
-                            .is_some_and(|f| f.load(Ordering::SeqCst));
+                        let stopped = stop_flag.as_ref().is_some_and(|f| f.load(Ordering::SeqCst));
                         if !stopped {
                             if stale_bestmove_warn.allow() {
                                 log::warn!(
@@ -375,9 +376,16 @@ impl EngineAnalyzer {
 /// `AnalysisConfig` から USI go コマンドを組み立てる。
 ///
 /// - `Time` は usi 0.6.2 が `go movetime` を ThinkParams で表現できないため byoyomi で近似
-/// - `Depth` / `Nodes` には ceiling として byoyomi 10 分を付け、閾値到達時の Stop で打ち切る
+/// - `Depth` / `Nodes` には ceiling として 24h byoyomi を付け、`should_stop_on_info` の
+///   threshold で Stop を送って打ち切る。ceiling は事実上 unlimited とし、
+///   深いモードでも byoyomi タイムアウトが先に来ないことを保証する
+///
+/// TODO(#107 follow-up): usi crate を拡張 / 自前 send_raw 経路を追加して
+/// `go movetime/depth/nodes` を直接送れるようにする。byoyomi 近似はそれまでの暫定。
 fn build_go_command(config: &AnalysisConfig) -> GuiCommand {
-    const THRESHOLD_CEILING: Duration = Duration::from_secs(600);
+    // 24 時間 — depth/nodes 系が threshold 到達まで byoyomi タイムアウトに当たらない
+    // よう実用上 unlimited なシーリング。フロントは `should_stop_on_info` で先に Stop を送る。
+    const THRESHOLD_CEILING: Duration = Duration::from_secs(24 * 60 * 60);
 
     let params = match config {
         AnalysisConfig::Infinite => ThinkParams::new().infinite(),

--- a/src-tauri/src/engine/bridge.rs
+++ b/src-tauri/src/engine/bridge.rs
@@ -46,15 +46,6 @@ struct AnalysisUpdate {
     result: AnalysisResult,
 }
 
-#[derive(Debug, Clone)]
-enum SessionType {
-    Infinite,
-    #[allow(dead_code)]
-    Timed(Duration),
-    #[allow(dead_code)]
-    Depth(u32),
-    Config(AnalysisMode),
-}
 
 impl EngineBridge {
     pub fn new() -> Self {
@@ -139,34 +130,6 @@ impl EngineBridge {
 
         log::debug!(target: LOGT, "set_position: ok");
         Ok(())
-    }
-
-    pub async fn start_infinite_analysis_impl(&self) -> Result<String, String> {
-        if let Err(e) = self.ensure_no_active_session().await {
-            log::warn!(target: LOGT, "start_infinite_analysis: rejected: {}", e);
-            return Err(e);
-        }
-
-        log::debug!(target: LOGT, "start_infinite_analysis: requested");
-
-        let result_rx = self.analyzer.start_infinite_analysis().await.map_err(|e| {
-            log::error!(
-                target: LOGT,
-                "start_infinite_analysis: analyzer failed: {:?}",
-                e
-            );
-            format!("Failed to start infinite analysis: {:?}", e)
-        })?;
-
-        let session_id = self.create_session(SessionType::Infinite).await;
-        log::info!(
-            target: LOGT,
-            "start_infinite_analysis: ok session_id={}",
-            session_id
-        );
-
-        self.start_result_forwarding(&session_id, result_rx).await;
-        Ok(session_id)
     }
 
     async fn start_result_forwarding(
@@ -268,47 +231,24 @@ impl EngineBridge {
             return Err(e);
         }
 
-        log::debug!(
-            target: LOGT,
-            "start_analysis: requested mode={:?}",
-            config.mode
-        );
+        let mode_tag = config.mode_tag();
+        log::debug!(target: LOGT, "start_analysis: requested mode={}", mode_tag);
 
-        let mode = config.mode;
-        let result_rx = self.analyzer.start_with_config(config).await.map_err(|e| {
+        let result_rx = self.analyzer.start_analysis(config).await.map_err(|e| {
             log::error!(target: LOGT, "start_analysis: analyzer failed: {:?}", e);
             format!("Failed to start analysis: {:?}", e)
         })?;
 
-        let session_id = self.create_session(SessionType::Config(mode)).await;
+        let session_id = self.create_session(mode_tag).await;
         log::info!(
             target: LOGT,
-            "start_analysis: ok session_id={} mode={:?}",
+            "start_analysis: ok session_id={} mode={}",
             session_id,
-            mode
+            mode_tag
         );
 
         self.start_result_forwarding(&session_id, result_rx).await;
         Ok(session_id)
-    }
-
-    pub async fn analyze_with_time_impl(
-        &self,
-        time_seconds: u64,
-    ) -> Result<AnalysisResult, String> {
-        let duration = Duration::from_secs(time_seconds);
-
-        self.analyzer
-            .analyze_with_time(duration)
-            .await
-            .map_err(|e| format!("Timed analysis failed: {:?}", e))
-    }
-
-    pub async fn analyze_with_depth_impl(&self, depth: u32) -> Result<AnalysisResult, String> {
-        self.analyzer
-            .analyze_with_depth(depth)
-            .await
-            .map_err(|e| format!("Depth analysis failed: {:?}", e))
     }
 
     pub async fn stop_analysis_impl(&self, session_id: Option<String>) -> Result<(), String> {
@@ -391,21 +331,9 @@ impl EngineBridge {
         }
     }
 
-    // ===  session === //
+    // === session === //
 
-    async fn create_session(&self, session_type: SessionType) -> String {
-        let prefix = match session_type {
-            SessionType::Infinite => "infinite",
-            SessionType::Timed(_) => "timed",
-            SessionType::Depth(_) => "depth",
-            SessionType::Config(mode) => match mode {
-                AnalysisMode::Infinite => "infinite",
-                AnalysisMode::Time => "time",
-                AnalysisMode::Depth => "depth",
-                AnalysisMode::Nodes => "nodes",
-                AnalysisMode::Mate => "mate",
-            },
-        };
+    async fn create_session(&self, prefix: &str) -> String {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -508,32 +436,11 @@ pub async fn set_position(
 }
 
 #[tauri::command]
-pub async fn start_infinite_analysis(state: tauri::State<'_, AppState>) -> Result<String, String> {
-    state.bridge.start_infinite_analysis_impl().await
-}
-
-#[tauri::command]
 pub async fn start_analysis(
     state: tauri::State<'_, AppState>,
     config: AnalysisConfig,
 ) -> Result<String, String> {
     state.bridge.start_analysis_impl(config).await
-}
-
-#[tauri::command]
-pub async fn analyze_with_time(
-    state: tauri::State<'_, AppState>,
-    time_seconds: u64,
-) -> Result<AnalysisResult, String> {
-    state.bridge.analyze_with_time_impl(time_seconds).await
-}
-
-#[tauri::command]
-pub async fn analyze_with_depth(
-    state: tauri::State<'_, AppState>,
-    depth: u32,
-) -> Result<AnalysisResult, String> {
-    state.bridge.analyze_with_depth_impl(depth).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/engine/bridge.rs
+++ b/src-tauri/src/engine/bridge.rs
@@ -46,7 +46,6 @@ struct AnalysisUpdate {
     result: AnalysisResult,
 }
 
-
 impl EngineBridge {
     pub fn new() -> Self {
         Self {
@@ -211,13 +210,36 @@ impl EngineBridge {
             // session が消えた後は、receiver を drop せずに drain 継続する
         }
 
-        // receiver が閉じた（analyzer 側が終了）ので最後に状態だけ落とす
-        {
+        // receiver が閉じた（analyzer 側が終了）ので最後に状態だけ落とす。
+        // 完了 event は finite モードの自然終了 (bestmove) と Infinite の外部 Stop
+        // 両方で必要 — フロント `AnalysisProvider` は `analysis-complete` でのみ
+        // `isAnalyzing` をクリアするので、ここで emit しないと UI が固着する。
+        let final_result = {
             let mut sessions_guard = sessions.write().await;
+            let final_result = sessions_guard
+                .get(&session_id)
+                .and_then(|s| s.last_result.clone());
             if let Some(session) = sessions_guard.get_mut(&session_id) {
                 session.is_active = false;
             }
+            final_result
+        };
+
+        if let Some(handle) = app_handle.read().await.clone() {
+            let payload = AnalysisUpdate {
+                session_id: session_id.clone(),
+                result: final_result.unwrap_or_default(),
+            };
+            if let Err(e) = handle.emit("analysis-complete", payload) {
+                log::warn!(
+                    target: LOGT,
+                    "forward_results: complete emit failed session_id={} err={}",
+                    session_id,
+                    e
+                );
+            }
         }
+
         log::debug!(
             target: LOGT,
             "forward_results: ended session_id={}",

--- a/src-tauri/src/engine/bridge.rs
+++ b/src-tauri/src/engine/bridge.rs
@@ -53,6 +53,7 @@ enum SessionType {
     Timed(Duration),
     #[allow(dead_code)]
     Depth(u32),
+    Config(AnalysisMode),
 }
 
 impl EngineBridge {
@@ -261,6 +262,36 @@ impl EngineBridge {
         );
     }
 
+    pub async fn start_analysis_impl(&self, config: AnalysisConfig) -> Result<String, String> {
+        if let Err(e) = self.ensure_no_active_session().await {
+            log::warn!(target: LOGT, "start_analysis: rejected: {}", e);
+            return Err(e);
+        }
+
+        log::debug!(
+            target: LOGT,
+            "start_analysis: requested mode={:?}",
+            config.mode
+        );
+
+        let mode = config.mode;
+        let result_rx = self.analyzer.start_with_config(config).await.map_err(|e| {
+            log::error!(target: LOGT, "start_analysis: analyzer failed: {:?}", e);
+            format!("Failed to start analysis: {:?}", e)
+        })?;
+
+        let session_id = self.create_session(SessionType::Config(mode)).await;
+        log::info!(
+            target: LOGT,
+            "start_analysis: ok session_id={} mode={:?}",
+            session_id,
+            mode
+        );
+
+        self.start_result_forwarding(&session_id, result_rx).await;
+        Ok(session_id)
+    }
+
     pub async fn analyze_with_time_impl(
         &self,
         time_seconds: u64,
@@ -367,6 +398,13 @@ impl EngineBridge {
             SessionType::Infinite => "infinite",
             SessionType::Timed(_) => "timed",
             SessionType::Depth(_) => "depth",
+            SessionType::Config(mode) => match mode {
+                AnalysisMode::Infinite => "infinite",
+                AnalysisMode::Time => "time",
+                AnalysisMode::Depth => "depth",
+                AnalysisMode::Nodes => "nodes",
+                AnalysisMode::Mate => "mate",
+            },
         };
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -472,6 +510,14 @@ pub async fn set_position(
 #[tauri::command]
 pub async fn start_infinite_analysis(state: tauri::State<'_, AppState>) -> Result<String, String> {
     state.bridge.start_infinite_analysis_impl().await
+}
+
+#[tauri::command]
+pub async fn start_analysis(
+    state: tauri::State<'_, AppState>,
+    config: AnalysisConfig,
+) -> Result<String, String> {
+    state.bridge.start_analysis_impl(config).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/engine/types.rs
+++ b/src-tauri/src/engine/types.rs
@@ -117,14 +117,31 @@ pub struct AnalysisStatus {
     pub analysis_count: u64,
 }
 
+/// 解析モード。go コマンドの形を決める。
+/// serde は lowercase（infinite/time/depth/nodes/mate）で受け渡す。
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnalysisMode {
+    #[default]
+    Infinite,
+    Time,
+    Depth,
+    Nodes,
+    Mate,
+}
+
 // 分析設定
-#[derive(Debug, Clone, Serialize, Deserialize)]
+//
+// MultiPV はここでは持たない — preset の USI options (`apply_engine_settings`) に統一済み。
+// `mate_search` は `mode == Mate` に置き換わったが、旧 JSON マイグレーション用にフィールドは残している。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AnalysisConfig {
+    pub mode: AnalysisMode,
     pub time_limit: Option<Duration>,
     pub depth_limit: Option<u32>,
     pub node_limit: Option<u64>,
+    #[serde(default)]
     pub mate_search: bool,
-    pub multi_pv: Option<u32>,
 }
 
 // 最善手情報

--- a/src-tauri/src/engine/types.rs
+++ b/src-tauri/src/engine/types.rs
@@ -117,31 +117,76 @@ pub struct AnalysisStatus {
     pub analysis_count: u64,
 }
 
-/// 解析モード。go コマンドの形を決める。
-/// serde は lowercase（infinite/time/depth/nodes/mate）で受け渡す。
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AnalysisMode {
+/// 解析の停止条件。これが「解析設定」の全て — 他の解析オプション（MultiPV など）は
+/// `apply_engine_settings` 経由の USI options に集約されている。
+///
+/// variant 名が serde tag `mode` を兼ねる。新しい停止条件を増やすときは variant を追加し、
+/// `should_stop_on_info` / `handle_bestmove` / `mode_tag` を更新する。
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "lowercase")]
+pub enum AnalysisConfig {
     #[default]
     Infinite,
-    Time,
-    Depth,
-    Nodes,
+    Time {
+        #[serde(rename = "timeSeconds")]
+        seconds: u64,
+    },
+    Depth {
+        #[serde(rename = "depth")]
+        plies: u32,
+    },
+    Nodes {
+        #[serde(rename = "nodes")]
+        count: u64,
+    },
     Mate,
 }
 
-// 分析設定
-//
-// MultiPV はここでは持たない — preset の USI options (`apply_engine_settings`) に統一済み。
-// `mate_search` は `mode == Mate` に置き換わったが、旧 JSON マイグレーション用にフィールドは残している。
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct AnalysisConfig {
-    pub mode: AnalysisMode,
-    pub time_limit: Option<Duration>,
-    pub depth_limit: Option<u32>,
-    pub node_limit: Option<u64>,
-    #[serde(default)]
-    pub mate_search: bool,
+/// bestmove を受け取ったときの処理方針。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BestmoveAction {
+    /// engine 自然終了。bestmove で stream 終了。
+    Finish,
+    /// 外部 stop を待っているモード（Infinite）。stop フラグが立つまでは stale として無視。
+    IgnoreUnlessStopped,
+}
+
+impl AnalysisConfig {
+    pub fn mode_tag(&self) -> &'static str {
+        match self {
+            Self::Infinite => "infinite",
+            Self::Time { .. } => "time",
+            Self::Depth { .. } => "depth",
+            Self::Nodes { .. } => "nodes",
+            Self::Mate => "mate",
+        }
+    }
+
+    /// rank 1 candidate の閾値が達したら true。閾値モードのみ意味を持つ。
+    pub fn should_stop_on_info(&self, result: &AnalysisResult) -> bool {
+        match self {
+            Self::Depth { plies } => result
+                .candidates
+                .iter()
+                .find(|c| c.rank == 1)
+                .and_then(|c| c.depth)
+                .is_some_and(|d| d >= *plies),
+            Self::Nodes { count } => result
+                .candidates
+                .iter()
+                .find(|c| c.rank == 1)
+                .and_then(|c| c.nodes)
+                .is_some_and(|n| n >= *count),
+            _ => false,
+        }
+    }
+
+    pub fn handle_bestmove(&self) -> BestmoveAction {
+        match self {
+            Self::Infinite => BestmoveAction::IgnoreUnlessStopped,
+            _ => BestmoveAction::Finish,
+        }
+    }
 }
 
 // 最善手情報
@@ -217,4 +262,144 @@ pub struct AnalysisCandidate {
 
     /// time は info time を受けるたび更新される
     pub time_ms: Option<u64>,
+}
+
+#[cfg(test)]
+mod analysis_config_tests {
+    use super::*;
+
+    fn candidate_with(rank: u32, depth: Option<u32>, nodes: Option<u64>) -> AnalysisCandidate {
+        AnalysisCandidate {
+            rank,
+            first_move: None,
+            pv_line: vec![],
+            evaluation: None,
+            depth,
+            nodes,
+            time_ms: None,
+        }
+    }
+
+    fn result_with(candidates: Vec<AnalysisCandidate>) -> AnalysisResult {
+        AnalysisResult {
+            candidates,
+            mate_sequence: None,
+        }
+    }
+
+    #[test]
+    fn mode_tag_returns_lowercase_variant_name() {
+        assert_eq!(AnalysisConfig::Infinite.mode_tag(), "infinite");
+        assert_eq!(AnalysisConfig::Time { seconds: 5 }.mode_tag(), "time");
+        assert_eq!(AnalysisConfig::Depth { plies: 5 }.mode_tag(), "depth");
+        assert_eq!(AnalysisConfig::Nodes { count: 5 }.mode_tag(), "nodes");
+        assert_eq!(AnalysisConfig::Mate.mode_tag(), "mate");
+    }
+
+    #[test]
+    fn handle_bestmove_finishes_for_non_infinite() {
+        assert_eq!(
+            AnalysisConfig::Time { seconds: 1 }.handle_bestmove(),
+            BestmoveAction::Finish
+        );
+        assert_eq!(
+            AnalysisConfig::Depth { plies: 1 }.handle_bestmove(),
+            BestmoveAction::Finish
+        );
+        assert_eq!(
+            AnalysisConfig::Nodes { count: 1 }.handle_bestmove(),
+            BestmoveAction::Finish
+        );
+        assert_eq!(AnalysisConfig::Mate.handle_bestmove(), BestmoveAction::Finish);
+    }
+
+    #[test]
+    fn handle_bestmove_for_infinite_waits_for_stop() {
+        assert_eq!(
+            AnalysisConfig::Infinite.handle_bestmove(),
+            BestmoveAction::IgnoreUnlessStopped
+        );
+    }
+
+    #[test]
+    fn should_stop_on_info_for_depth_when_reached() {
+        let cfg = AnalysisConfig::Depth { plies: 10 };
+        let r = result_with(vec![candidate_with(1, Some(10), None)]);
+        assert!(cfg.should_stop_on_info(&r));
+    }
+
+    #[test]
+    fn should_stop_on_info_for_depth_not_reached() {
+        let cfg = AnalysisConfig::Depth { plies: 10 };
+        let r = result_with(vec![candidate_with(1, Some(9), None)]);
+        assert!(!cfg.should_stop_on_info(&r));
+    }
+
+    #[test]
+    fn should_stop_on_info_for_depth_uses_rank1_only() {
+        // rank 2 が閾値に達しても rank 1 が達していなければ false
+        let cfg = AnalysisConfig::Depth { plies: 10 };
+        let r = result_with(vec![
+            candidate_with(1, Some(5), None),
+            candidate_with(2, Some(20), None),
+        ]);
+        assert!(!cfg.should_stop_on_info(&r));
+    }
+
+    #[test]
+    fn should_stop_on_info_for_nodes_when_reached() {
+        let cfg = AnalysisConfig::Nodes { count: 100_000 };
+        let r = result_with(vec![candidate_with(1, None, Some(100_000))]);
+        assert!(cfg.should_stop_on_info(&r));
+    }
+
+    #[test]
+    fn should_stop_on_info_for_nodes_not_reached() {
+        let cfg = AnalysisConfig::Nodes { count: 100_000 };
+        let r = result_with(vec![candidate_with(1, None, Some(99_999))]);
+        assert!(!cfg.should_stop_on_info(&r));
+    }
+
+    #[test]
+    fn should_stop_on_info_false_for_non_threshold_modes() {
+        let r = result_with(vec![candidate_with(1, Some(99), Some(99_999_999))]);
+        assert!(!AnalysisConfig::Infinite.should_stop_on_info(&r));
+        assert!(!AnalysisConfig::Time { seconds: 1 }.should_stop_on_info(&r));
+        assert!(!AnalysisConfig::Mate.should_stop_on_info(&r));
+    }
+
+    #[test]
+    fn serde_roundtrip_time() {
+        let cfg = AnalysisConfig::Time { seconds: 30 };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(json, r#"{"mode":"time","timeSeconds":30}"#);
+        let back: AnalysisConfig = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, AnalysisConfig::Time { seconds: 30 }));
+    }
+
+    #[test]
+    fn serde_roundtrip_depth() {
+        let cfg = AnalysisConfig::Depth { plies: 20 };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(json, r#"{"mode":"depth","depth":20}"#);
+    }
+
+    #[test]
+    fn serde_roundtrip_nodes() {
+        let cfg = AnalysisConfig::Nodes { count: 1_000_000 };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(json, r#"{"mode":"nodes","nodes":1000000}"#);
+    }
+
+    #[test]
+    fn serde_roundtrip_bare_variants() {
+        assert_eq!(
+            serde_json::to_string(&AnalysisConfig::Infinite).unwrap(),
+            r#"{"mode":"infinite"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&AnalysisConfig::Mate).unwrap(),
+            r#"{"mode":"mate"}"#
+        );
+    }
 }

--- a/src-tauri/src/engine/types.rs
+++ b/src-tauri/src/engine/types.rs
@@ -310,7 +310,10 @@ mod analysis_config_tests {
             AnalysisConfig::Nodes { count: 1 }.handle_bestmove(),
             BestmoveAction::Finish
         );
-        assert_eq!(AnalysisConfig::Mate.handle_bestmove(), BestmoveAction::Finish);
+        assert_eq!(
+            AnalysisConfig::Mate.handle_bestmove(),
+            BestmoveAction::Finish
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,9 +11,9 @@ pub use crate::engine::bridge::AppState;
 pub use ai_library::{ensure_engines_dir, scan_ai_root};
 pub use config_dir::{load_config, save_config};
 pub use engine::bridge::{
-    analyze_with_depth, analyze_with_time, apply_engine_settings, get_analysis_result,
-    get_analysis_status, get_engine_info, get_engine_settings, get_last_result, initialize_engine,
-    set_position, shutdown_engine, start_analysis, start_infinite_analysis, stop_analysis,
+    apply_engine_settings, get_analysis_result, get_analysis_status, get_engine_info,
+    get_engine_settings, get_last_result, initialize_engine, set_position, shutdown_engine,
+    start_analysis, stop_analysis,
 };
 pub use engine_presets::{load_presets, save_presets};
 pub use file_system::{
@@ -74,10 +74,7 @@ pub fn run() {
             initialize_engine,
             shutdown_engine,
             set_position,
-            start_infinite_analysis,
             start_analysis,
-            analyze_with_time,
-            analyze_with_depth,
             stop_analysis,
             get_analysis_result,
             get_last_result,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ pub use config_dir::{load_config, save_config};
 pub use engine::bridge::{
     analyze_with_depth, analyze_with_time, apply_engine_settings, get_analysis_result,
     get_analysis_status, get_engine_info, get_engine_settings, get_last_result, initialize_engine,
-    set_position, shutdown_engine, start_infinite_analysis, stop_analysis,
+    set_position, shutdown_engine, start_analysis, start_infinite_analysis, stop_analysis,
 };
 pub use engine_presets::{load_presets, save_presets};
 pub use file_system::{
@@ -75,6 +75,7 @@ pub fn run() {
             shutdown_engine,
             set_position,
             start_infinite_analysis,
+            start_analysis,
             analyze_with_time,
             analyze_with_depth,
             stop_analysis,

--- a/src/app/providers/bridges/AnalysisBridge.tsx
+++ b/src/app/providers/bridges/AnalysisBridge.tsx
@@ -1,12 +1,17 @@
 import type { ReactNode } from "react";
 import { AnalysisProvider } from "@/entities/analysis";
 import { usePositionSync } from "@/app/providers/bridges/position-sync";
+import { useEnginePresets } from "@/entities/engine-presets/model/useEnginePresets";
 
 export function AnalysisBridge({ children }: { children: ReactNode }) {
   const { currentSfen, syncedSfen, syncPosition } = usePositionSync();
+  const { analysisDefaults } = useEnginePresets();
 
   return (
-    <AnalysisProvider positionSync={{ currentSfen, syncedSfen, syncPosition }}>
+    <AnalysisProvider
+      positionSync={{ currentSfen, syncedSfen, syncPosition }}
+      analysisDefaults={analysisDefaults}
+    >
       {children}
     </AnalysisProvider>
   );

--- a/src/app/providers/bridges/AnalysisBridge.tsx
+++ b/src/app/providers/bridges/AnalysisBridge.tsx
@@ -1,16 +1,19 @@
-import type { ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 import { AnalysisProvider } from "@/entities/analysis";
 import { usePositionSync } from "@/app/providers/bridges/position-sync";
 import { useEnginePresets } from "@/entities/engine-presets/model/useEnginePresets";
+import { buildAnalysisConfig } from "@/entities/engine-presets/lib/buildAnalysisConfig";
 
 export function AnalysisBridge({ children }: { children: ReactNode }) {
   const { currentSfen, syncedSfen, syncPosition } = usePositionSync();
   const { analysisDefaults } = useEnginePresets();
 
+  const buildConfig = useCallback(() => buildAnalysisConfig(analysisDefaults), [analysisDefaults]);
+
   return (
     <AnalysisProvider
       positionSync={{ currentSfen, syncedSfen, syncPosition }}
-      analysisDefaults={analysisDefaults}
+      buildConfig={buildConfig}
     >
       {children}
     </AnalysisProvider>

--- a/src/entities/analysis/model/provider.tsx
+++ b/src/entities/analysis/model/provider.tsx
@@ -9,52 +9,32 @@ import { analysisReducer, initialState } from "./reducer";
 import { useEngine, type AnalysisResult } from "@/entities/engine";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { setupAnalysisEventListeners } from "@/entities/engine/api/events";
-import type { AnalysisCandidate, AnalysisConfig, Duration } from "@/entities/engine/api/rust-types";
-import type { AnalysisDefaults } from "@/entities/engine-presets/model/types";
+import type { AnalysisCandidate, AnalysisConfig } from "@/entities/engine/api/rust-types";
 import { pickTopCandidate } from "../lib/candidates";
 import { AnalysisContext } from "./context";
 
 interface Props {
   children: ReactNode;
   positionSync: PositionSyncAdapter;
-  /** preset から注入される解析既定値。null/未指定なら infinite。 */
-  analysisDefaults?: AnalysisDefaults | null;
+  /**
+   * 解析開始時に呼ばれる config ビルダ。bridge 層が preset などの外部依存を解決した上で
+   * `AnalysisConfig` を供給する責務を持つ (Strategy 注入)。
+   */
+  buildConfig: () => AnalysisConfig;
 }
 
-function toDuration(seconds: number): Duration {
-  const safe = Math.max(0, Math.floor(seconds));
-  return { secs: safe, nanos: 0 };
-}
-
-function buildAnalysisConfig(defaults: AnalysisDefaults | null | undefined): AnalysisConfig {
-  if (!defaults) {
-    return { mode: "infinite" };
-  }
-  const time =
-    defaults.timeSeconds != null && defaults.timeSeconds > 0
-      ? toDuration(defaults.timeSeconds)
-      : undefined;
-  return {
-    mode: defaults.mode,
-    time_limit: time,
-    depth_limit: defaults.depth,
-    node_limit: defaults.nodes,
-    mate_search: defaults.mode === "mate",
-  };
-}
-
-export function AnalysisProvider({ children, positionSync, analysisDefaults }: Props) {
+export function AnalysisProvider({ children, positionSync, buildConfig }: Props) {
   const [state, dispatch] = useReducer(analysisReducer, initialState);
 
   const { isReady } = useEngine();
 
   const { currentSfen, syncedSfen, syncPosition } = positionSync;
 
-  // 解析中の preset 切り替えにも追従できるよう ref に最新値を保つ
-  const analysisDefaultsRef = useRef<AnalysisDefaults | null>(analysisDefaults ?? null);
+  // 解析中の preset 切り替えにも追従できるよう最新 builder を ref に保つ
+  const buildConfigRef = useRef(buildConfig);
   useEffect(() => {
-    analysisDefaultsRef.current = analysisDefaults ?? null;
-  }, [analysisDefaults]);
+    buildConfigRef.current = buildConfig;
+  }, [buildConfig]);
 
   const unlistenRef = useRef<UnlistenFn | null>(null);
 
@@ -221,9 +201,7 @@ export function AnalysisProvider({ children, positionSync, analysisDefaults }: P
 
         clearFlushTimer();
         latestResultRef.current = null;
-        const newSessionId = await startAnalysisCore(
-          buildAnalysisConfig(analysisDefaultsRef.current),
-        );
+        const newSessionId = await startAnalysisCore(buildConfigRef.current());
 
         dispatch({
           type: "start_analysis",
@@ -300,7 +278,7 @@ export function AnalysisProvider({ children, positionSync, analysisDefaults }: P
 
     await waitUntil(() => syncedSfenRef.current === currentSfen, 2000);
 
-    const sessionId = await startAnalysisCore(buildAnalysisConfig(analysisDefaultsRef.current));
+    const sessionId = await startAnalysisCore(buildConfigRef.current());
 
     dispatch({
       type: "start_analysis",
@@ -310,9 +288,6 @@ export function AnalysisProvider({ children, positionSync, analysisDefaults }: P
     lastAnalyzedSfenRef.current = currentSfen;
     desiredSfenRef.current = currentSfen;
   }, [isReady, state.isAnalyzing, currentSfen, syncPosition]);
-
-  // 後方互換 alias
-  const startInfiniteAnalysis = startAnalysis;
 
   const stopAnalysis = useCallback(async () => {
     desiredSfenRef.current = null;
@@ -354,7 +329,6 @@ export function AnalysisProvider({ children, positionSync, analysisDefaults }: P
     () => ({
       state,
       startAnalysis,
-      startInfiniteAnalysis,
       stopAnalysis,
       clearResults,
       clearError,
@@ -364,7 +338,6 @@ export function AnalysisProvider({ children, positionSync, analysisDefaults }: P
     [
       state,
       startAnalysis,
-      startInfiniteAnalysis,
       stopAnalysis,
       clearResults,
       clearError,

--- a/src/entities/analysis/model/provider.tsx
+++ b/src/entities/analysis/model/provider.tsx
@@ -2,28 +2,59 @@ import { isTauri } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useMemo, useReducer, useRef, type ReactNode } from "react";
 import type { AnalysisContextType, PositionSyncAdapter } from "./types";
 import {
-  startInfiniteAnalysis as startInfiniteAnalysisCore,
+  startAnalysis as startAnalysisCore,
   stopAnalysis as stopAnalysisCore,
 } from "@/entities/engine/api/tauri";
 import { analysisReducer, initialState } from "./reducer";
 import { useEngine, type AnalysisResult } from "@/entities/engine";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { setupAnalysisEventListeners } from "@/entities/engine/api/events";
-import type { AnalysisCandidate } from "@/entities/engine/api/rust-types";
+import type { AnalysisCandidate, AnalysisConfig, Duration } from "@/entities/engine/api/rust-types";
+import type { AnalysisDefaults } from "@/entities/engine-presets/model/types";
 import { pickTopCandidate } from "../lib/candidates";
 import { AnalysisContext } from "./context";
 
 interface Props {
   children: ReactNode;
   positionSync: PositionSyncAdapter;
+  /** preset から注入される解析既定値。null/未指定なら infinite。 */
+  analysisDefaults?: AnalysisDefaults | null;
 }
 
-export function AnalysisProvider({ children, positionSync }: Props) {
+function toDuration(seconds: number): Duration {
+  const safe = Math.max(0, Math.floor(seconds));
+  return { secs: safe, nanos: 0 };
+}
+
+function buildAnalysisConfig(defaults: AnalysisDefaults | null | undefined): AnalysisConfig {
+  if (!defaults) {
+    return { mode: "infinite" };
+  }
+  const time =
+    defaults.timeSeconds != null && defaults.timeSeconds > 0
+      ? toDuration(defaults.timeSeconds)
+      : undefined;
+  return {
+    mode: defaults.mode,
+    time_limit: time,
+    depth_limit: defaults.depth,
+    node_limit: defaults.nodes,
+    mate_search: defaults.mode === "mate",
+  };
+}
+
+export function AnalysisProvider({ children, positionSync, analysisDefaults }: Props) {
   const [state, dispatch] = useReducer(analysisReducer, initialState);
 
   const { isReady } = useEngine();
 
   const { currentSfen, syncedSfen, syncPosition } = positionSync;
+
+  // 解析中の preset 切り替えにも追従できるよう ref に最新値を保つ
+  const analysisDefaultsRef = useRef<AnalysisDefaults | null>(analysisDefaults ?? null);
+  useEffect(() => {
+    analysisDefaultsRef.current = analysisDefaults ?? null;
+  }, [analysisDefaults]);
 
   const unlistenRef = useRef<UnlistenFn | null>(null);
 
@@ -190,7 +221,9 @@ export function AnalysisProvider({ children, positionSync }: Props) {
 
         clearFlushTimer();
         latestResultRef.current = null;
-        const newSessionId = await startInfiniteAnalysisCore();
+        const newSessionId = await startAnalysisCore(
+          buildAnalysisConfig(analysisDefaultsRef.current),
+        );
 
         dispatch({
           type: "start_analysis",
@@ -258,7 +291,7 @@ export function AnalysisProvider({ children, positionSync }: Props) {
     }
   }, [syncedSfen, state.isAnalyzing, isReady]);
 
-  const startInfiniteAnalysis = useCallback(async () => {
+  const startAnalysis = useCallback(async () => {
     if (!isReady) throw new Error("Engine not ready");
     if (state.isAnalyzing) return;
     if (!currentSfen) throw new Error("No position available for analysis");
@@ -267,7 +300,7 @@ export function AnalysisProvider({ children, positionSync }: Props) {
 
     await waitUntil(() => syncedSfenRef.current === currentSfen, 2000);
 
-    const sessionId = await startInfiniteAnalysisCore();
+    const sessionId = await startAnalysisCore(buildAnalysisConfig(analysisDefaultsRef.current));
 
     dispatch({
       type: "start_analysis",
@@ -277,6 +310,9 @@ export function AnalysisProvider({ children, positionSync }: Props) {
     lastAnalyzedSfenRef.current = currentSfen;
     desiredSfenRef.current = currentSfen;
   }, [isReady, state.isAnalyzing, currentSfen, syncPosition]);
+
+  // 後方互換 alias
+  const startInfiniteAnalysis = startAnalysis;
 
   const stopAnalysis = useCallback(async () => {
     desiredSfenRef.current = null;
@@ -317,6 +353,7 @@ export function AnalysisProvider({ children, positionSync }: Props) {
   const value = useMemo<AnalysisContextType>(
     () => ({
       state,
+      startAnalysis,
       startInfiniteAnalysis,
       stopAnalysis,
       clearResults,
@@ -326,6 +363,7 @@ export function AnalysisProvider({ children, positionSync }: Props) {
     }),
     [
       state,
+      startAnalysis,
       startInfiniteAnalysis,
       stopAnalysis,
       clearResults,

--- a/src/entities/analysis/model/types.ts
+++ b/src/entities/analysis/model/types.ts
@@ -26,6 +26,12 @@ export type PositionSyncAdapter = {
 export interface AnalysisContextType {
   state: AnalysisState;
 
+  /**
+   * preset の analysisDefaults に従って解析を開始する。
+   * mode/閾値の選択は preset 側に集約される。
+   */
+  startAnalysis: () => Promise<void>;
+  /** 後方互換 alias。内部で `startAnalysis()` に転送する。 */
   startInfiniteAnalysis: () => Promise<void>;
   stopAnalysis: () => Promise<void>;
   clearResults: () => void;

--- a/src/entities/analysis/model/types.ts
+++ b/src/entities/analysis/model/types.ts
@@ -27,12 +27,10 @@ export interface AnalysisContextType {
   state: AnalysisState;
 
   /**
-   * preset の analysisDefaults に従って解析を開始する。
-   * mode/閾値の選択は preset 側に集約される。
+   * 注入された `buildConfig()` に従って解析を開始する。
+   * mode/閾値などの選択は bridge 層 (= preset 等の外部依存を持つ層) に委ねられる。
    */
   startAnalysis: () => Promise<void>;
-  /** 後方互換 alias。内部で `startAnalysis()` に転送する。 */
-  startInfiniteAnalysis: () => Promise<void>;
   stopAnalysis: () => Promise<void>;
   clearResults: () => void;
   clearError: () => void;

--- a/src/entities/engine-presets/lib/buildAnalysisConfig.test.ts
+++ b/src/entities/engine-presets/lib/buildAnalysisConfig.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from "vitest";
+import { buildAnalysisConfig } from "./buildAnalysisConfig";
+import type { AnalysisDefaults } from "../model/types";
+
+describe("buildAnalysisConfig", () => {
+  test("returns infinite when defaults is null", () => {
+    expect(buildAnalysisConfig(null)).toEqual({ mode: "infinite" });
+  });
+
+  test("returns infinite when defaults is undefined", () => {
+    expect(buildAnalysisConfig(undefined)).toEqual({ mode: "infinite" });
+  });
+
+  test("infinite mode passes through", () => {
+    const defaults: AnalysisDefaults = { mode: "infinite" };
+    expect(buildAnalysisConfig(defaults)).toEqual({ mode: "infinite" });
+  });
+
+  test("time mode uses provided timeSeconds", () => {
+    const defaults: AnalysisDefaults = { mode: "time", timeSeconds: 30 };
+    expect(buildAnalysisConfig(defaults)).toEqual({ mode: "time", timeSeconds: 30 });
+  });
+
+  test("time mode falls back to default when timeSeconds is missing", () => {
+    const defaults: AnalysisDefaults = { mode: "time" };
+    const result = buildAnalysisConfig(defaults);
+    expect(result.mode).toBe("time");
+    if (result.mode === "time") {
+      expect(result.timeSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  test("time mode falls back when timeSeconds is zero", () => {
+    const defaults: AnalysisDefaults = { mode: "time", timeSeconds: 0 };
+    const result = buildAnalysisConfig(defaults);
+    expect(result.mode).toBe("time");
+    if (result.mode === "time") {
+      expect(result.timeSeconds).toBeGreaterThan(0);
+    }
+  });
+
+  test("depth mode uses provided depth", () => {
+    const defaults: AnalysisDefaults = { mode: "depth", depth: 25 };
+    expect(buildAnalysisConfig(defaults)).toEqual({ mode: "depth", depth: 25 });
+  });
+
+  test("depth mode falls back when depth is missing", () => {
+    const defaults: AnalysisDefaults = { mode: "depth" };
+    const result = buildAnalysisConfig(defaults);
+    expect(result.mode).toBe("depth");
+    if (result.mode === "depth") {
+      expect(result.depth).toBeGreaterThan(0);
+    }
+  });
+
+  test("nodes mode uses provided nodes", () => {
+    const defaults: AnalysisDefaults = { mode: "nodes", nodes: 5_000_000 };
+    expect(buildAnalysisConfig(defaults)).toEqual({ mode: "nodes", nodes: 5_000_000 });
+  });
+
+  test("nodes mode falls back when nodes is missing", () => {
+    const defaults: AnalysisDefaults = { mode: "nodes" };
+    const result = buildAnalysisConfig(defaults);
+    expect(result.mode).toBe("nodes");
+    if (result.mode === "nodes") {
+      expect(result.nodes).toBeGreaterThan(0);
+    }
+  });
+
+  test("mate mode produces bare variant", () => {
+    const defaults: AnalysisDefaults = { mode: "mate" };
+    expect(buildAnalysisConfig(defaults)).toEqual({ mode: "mate" });
+  });
+
+  test("ignores unrelated fields when mode is infinite", () => {
+    const defaults: AnalysisDefaults = {
+      mode: "infinite",
+      timeSeconds: 999,
+      depth: 99,
+      nodes: 999_999,
+    };
+    expect(buildAnalysisConfig(defaults)).toEqual({ mode: "infinite" });
+  });
+});

--- a/src/entities/engine-presets/lib/buildAnalysisConfig.ts
+++ b/src/entities/engine-presets/lib/buildAnalysisConfig.ts
@@ -1,0 +1,41 @@
+import type { AnalysisConfig } from "@/entities/engine/api/rust-types";
+import type { AnalysisDefaults } from "../model/types";
+
+// UI form は欠損を許容するため、Rust に渡す直前のフォールバック値をここで一元化する。
+const DEFAULT_TIME_SECONDS = 10;
+const DEFAULT_DEPTH_PLIES = 20;
+const DEFAULT_NODES_COUNT = 1_000_000;
+
+/**
+ * preset の flat な {@link AnalysisDefaults} を Rust 側の discriminated union
+ * {@link AnalysisConfig} に変換する。
+ *
+ * preset が無い (`null`/`undefined`) 場合は `infinite` にフォールバック。
+ */
+export function buildAnalysisConfig(defaults: AnalysisDefaults | null | undefined): AnalysisConfig {
+  if (!defaults) return { mode: "infinite" };
+
+  switch (defaults.mode) {
+    case "infinite":
+      return { mode: "infinite" };
+    case "time": {
+      const seconds =
+        defaults.timeSeconds != null && defaults.timeSeconds > 0
+          ? defaults.timeSeconds
+          : DEFAULT_TIME_SECONDS;
+      return { mode: "time", timeSeconds: seconds };
+    }
+    case "depth": {
+      const plies =
+        defaults.depth != null && defaults.depth > 0 ? defaults.depth : DEFAULT_DEPTH_PLIES;
+      return { mode: "depth", depth: plies };
+    }
+    case "nodes": {
+      const count =
+        defaults.nodes != null && defaults.nodes > 0 ? defaults.nodes : DEFAULT_NODES_COUNT;
+      return { mode: "nodes", nodes: count };
+    }
+    case "mate":
+      return { mode: "mate" };
+  }
+}

--- a/src/entities/engine-presets/lib/buildAnalysisConfig.ts
+++ b/src/entities/engine-presets/lib/buildAnalysisConfig.ts
@@ -2,9 +2,10 @@ import type { AnalysisConfig } from "@/entities/engine/api/rust-types";
 import type { AnalysisDefaults } from "../model/types";
 
 // UI form は欠損を許容するため、Rust に渡す直前のフォールバック値をここで一元化する。
-const DEFAULT_TIME_SECONDS = 10;
+// AnalysisDefaultsSection の placeholder と同期させること。
+const DEFAULT_TIME_SECONDS = 30;
 const DEFAULT_DEPTH_PLIES = 20;
-const DEFAULT_NODES_COUNT = 1_000_000;
+const DEFAULT_NODES_COUNT = 100_000_000;
 
 /**
  * preset の flat な {@link AnalysisDefaults} を Rust 側の discriminated union

--- a/src/entities/engine-presets/lib/normalize.test.ts
+++ b/src/entities/engine-presets/lib/normalize.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from "vitest";
+import { normalizeOnePreset } from "./normalize";
+import type { EnginePreset } from "../model/types";
+
+function makeRaw(analysis: Record<string, unknown> | undefined): Partial<EnginePreset> {
+  return {
+    id: "test-id",
+    label: "x",
+    aiName: "x",
+    enginePath: "/x",
+    evalFilePath: "/x",
+    bookEnabled: false,
+    bookFilePath: null,
+    options: {},
+    analysis: analysis as never,
+  };
+}
+
+describe("normalizeOnePreset analysis migration", () => {
+  test("infers mate from legacy mateSearch=true when mode missing", () => {
+    const raw = makeRaw({ mateSearch: true });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("mate");
+  });
+
+  test("infers time from legacy timeSeconds when mode missing", () => {
+    const raw = makeRaw({ timeSeconds: 15 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("time");
+    expect(p.analysis?.timeSeconds).toBe(15);
+  });
+
+  test("infers depth from legacy depth when mode missing and no time", () => {
+    const raw = makeRaw({ depth: 22 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("depth");
+  });
+
+  test("infers nodes from legacy nodes when only nodes present", () => {
+    const raw = makeRaw({ nodes: 100_000 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("nodes");
+  });
+
+  test("defaults to infinite when no signal is present", () => {
+    const raw = makeRaw({});
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("infinite");
+  });
+
+  test("mate inference takes priority over time/depth/nodes", () => {
+    const raw = makeRaw({ mateSearch: true, timeSeconds: 10, depth: 5, nodes: 100 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("mate");
+  });
+
+  test("time inference takes priority over depth/nodes (when no mate)", () => {
+    const raw = makeRaw({ timeSeconds: 10, depth: 5, nodes: 100 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("time");
+  });
+
+  test("explicit mode wins over legacy fields", () => {
+    const raw = makeRaw({ mode: "infinite", mateSearch: true, timeSeconds: 10 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.mode).toBe("infinite");
+  });
+
+  test("drops mateSearch field from normalized output", () => {
+    const raw = makeRaw({ mateSearch: true });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis).not.toHaveProperty("mateSearch");
+  });
+
+  test("drops timeSeconds when <= 0", () => {
+    const raw = makeRaw({ mode: "time", timeSeconds: 0 });
+    const p = normalizeOnePreset(raw);
+    expect(p.analysis?.timeSeconds).toBeUndefined();
+  });
+});

--- a/src/entities/engine-presets/lib/normalize.ts
+++ b/src/entities/engine-presets/lib/normalize.ts
@@ -1,5 +1,24 @@
 import { DEFAULT_USI_OPTIONS } from "../model/defaultOptions";
-import type { EnginePreset, PresetId, PresetsFile, UsiOptionMap } from "../model/types";
+import type {
+  AnalysisDefaults,
+  EnginePreset,
+  PresetId,
+  PresetsFile,
+  UsiOptionMap,
+} from "../model/types";
+import type { AnalysisMode } from "@/entities/engine/api/rust-types";
+
+/**
+ * `mode` を欠いた旧 preset JSON から mode を推定する。
+ * 優先順: mate(=mateSearch true) > time > depth > nodes > infinite
+ */
+function inferAnalysisMode(a: Partial<AnalysisDefaults>): AnalysisMode {
+  if (a.mateSearch) return "mate";
+  if (a.timeSeconds != null && a.timeSeconds > 0) return "time";
+  if (a.depth != null && a.depth > 0) return "depth";
+  if (a.nodes != null && a.nodes > 0) return "nodes";
+  return "infinite";
+}
 
 export function genPresetId(): PresetId {
   return crypto.randomUUID();
@@ -65,11 +84,21 @@ export function normalizeOnePreset(raw: Partial<EnginePreset>): EnginePreset {
   p.options = { ...DEFAULT_USI_OPTIONS, ...nextOptions };
 
   if (p.analysis) {
-    const a = { ...p.analysis };
+    const a: Partial<AnalysisDefaults> = { ...p.analysis };
     if (a.timeSeconds != null && a.timeSeconds <= 0) delete a.timeSeconds;
     if (a.depth != null && a.depth <= 0) delete a.depth;
     if (a.nodes != null && a.nodes <= 0) delete a.nodes;
-    p.analysis = a;
+
+    // mode が無い旧 JSON は legacy field から推定する
+    const mode: AnalysisMode = a.mode ?? inferAnalysisMode(a);
+    p.analysis = {
+      mode,
+      timeSeconds: a.timeSeconds,
+      depth: a.depth,
+      nodes: a.nodes,
+      // 派生値: mate モードなら true
+      mateSearch: mode === "mate",
+    };
   }
 
   return p;

--- a/src/entities/engine-presets/lib/normalize.ts
+++ b/src/entities/engine-presets/lib/normalize.ts
@@ -10,9 +10,9 @@ import type { AnalysisMode } from "@/entities/engine/api/rust-types";
 
 /**
  * `mode` を欠いた旧 preset JSON から mode を推定する。
- * 優先順: mate(=mateSearch true) > time > depth > nodes > infinite
+ * 優先順: mate (legacy `mateSearch: true`) > time > depth > nodes > infinite
  */
-function inferAnalysisMode(a: Partial<AnalysisDefaults>): AnalysisMode {
+function inferAnalysisMode(a: Partial<AnalysisDefaults> & { mateSearch?: boolean }): AnalysisMode {
   if (a.mateSearch) return "mate";
   if (a.timeSeconds != null && a.timeSeconds > 0) return "time";
   if (a.depth != null && a.depth > 0) return "depth";
@@ -84,20 +84,19 @@ export function normalizeOnePreset(raw: Partial<EnginePreset>): EnginePreset {
   p.options = { ...DEFAULT_USI_OPTIONS, ...nextOptions };
 
   if (p.analysis) {
-    const a: Partial<AnalysisDefaults> = { ...p.analysis };
+    const a: Partial<AnalysisDefaults> & { mateSearch?: boolean } = { ...p.analysis };
     if (a.timeSeconds != null && a.timeSeconds <= 0) delete a.timeSeconds;
     if (a.depth != null && a.depth <= 0) delete a.depth;
     if (a.nodes != null && a.nodes <= 0) delete a.nodes;
 
-    // mode が無い旧 JSON は legacy field から推定する
+    // mode が無い旧 JSON は legacy field から推定する。`mateSearch` は読み取り側のみで、
+    // 正規化後のフィールドからは落とす (mode === "mate" が新しい単一ソース)。
     const mode: AnalysisMode = a.mode ?? inferAnalysisMode(a);
     p.analysis = {
       mode,
       timeSeconds: a.timeSeconds,
       depth: a.depth,
       nodes: a.nodes,
-      // 派生値: mate モードなら true
-      mateSearch: mode === "mate",
     };
   }
 

--- a/src/entities/engine-presets/model/provider.tsx
+++ b/src/entities/engine-presets/model/provider.tsx
@@ -82,14 +82,11 @@ export function EnginePresetsProvider({ children }: { children: ReactNode }) {
     if (!selectedPreset) return null;
 
     const a = selectedPreset.analysis;
-    const mode = a?.mode ?? "infinite";
-
     return {
-      mode,
+      mode: a?.mode ?? "infinite",
       timeSeconds: a?.timeSeconds,
       depth: a?.depth,
       nodes: a?.nodes,
-      mateSearch: mode === "mate",
     };
   }, [selectedPreset]);
 

--- a/src/entities/engine-presets/model/provider.tsx
+++ b/src/entities/engine-presets/model/provider.tsx
@@ -82,12 +82,14 @@ export function EnginePresetsProvider({ children }: { children: ReactNode }) {
     if (!selectedPreset) return null;
 
     const a = selectedPreset.analysis;
+    const mode = a?.mode ?? "infinite";
 
     return {
+      mode,
       timeSeconds: a?.timeSeconds,
       depth: a?.depth,
       nodes: a?.nodes,
-      mateSearch: a?.mateSearch ?? false,
+      mateSearch: mode === "mate",
     };
   }, [selectedPreset]);
 

--- a/src/entities/engine-presets/model/types.ts
+++ b/src/entities/engine-presets/model/types.ts
@@ -1,12 +1,16 @@
 import type { EngineRuntimeConfig } from "@/entities/engine/model/types";
+import type { AnalysisMode } from "@/entities/engine/api/rust-types";
 
 export type PresetId = string;
 export type UsiOptionMap = Record<string, string>;
 
 export type AnalysisDefaults = {
+  /** 解析モード。go コマンドの形を決める唯一のソース。 */
+  mode: AnalysisMode;
   timeSeconds?: number;
   depth?: number;
   nodes?: number;
+  /** 旧フィールド。`mode === "mate"` の派生として保持。新規コードでは mode を見る。 */
   mateSearch: boolean;
 };
 

--- a/src/entities/engine-presets/model/types.ts
+++ b/src/entities/engine-presets/model/types.ts
@@ -4,14 +4,12 @@ import type { AnalysisMode } from "@/entities/engine/api/rust-types";
 export type PresetId = string;
 export type UsiOptionMap = Record<string, string>;
 
+/** preset disk format で持つ解析既定値。フラット保持 (旧 JSON 互換)。 */
 export type AnalysisDefaults = {
-  /** 解析モード。go コマンドの形を決める唯一のソース。 */
   mode: AnalysisMode;
   timeSeconds?: number;
   depth?: number;
   nodes?: number;
-  /** 旧フィールド。`mode === "mate"` の派生として保持。新規コードでは mode を見る。 */
-  mateSearch: boolean;
 };
 
 export type EnginePreset = {

--- a/src/entities/engine/api/rust-types.ts
+++ b/src/entities/engine/api/rust-types.ts
@@ -29,12 +29,15 @@ export interface EngineSettings {
   options: Record<string, string>;
 }
 
+export type AnalysisMode = "infinite" | "time" | "depth" | "nodes" | "mate";
+
 export interface AnalysisConfig {
+  mode: AnalysisMode;
   time_limit?: Duration;
   depth_limit?: number;
   node_limit?: number;
-  mate_search: boolean;
-  multi_pv?: number;
+  /** legacy field — kept so旧 JSON のシリアライズが落ちないように。新規コードは mode を使う */
+  mate_search?: boolean;
 }
 
 export interface AnalysisStatus {

--- a/src/entities/engine/api/rust-types.ts
+++ b/src/entities/engine/api/rust-types.ts
@@ -29,16 +29,18 @@ export interface EngineSettings {
   options: Record<string, string>;
 }
 
-export type AnalysisMode = "infinite" | "time" | "depth" | "nodes" | "mate";
+/**
+ * 解析の停止条件。これが「解析設定」の全て — 他の解析オプション (MultiPV など) は
+ * `apply_engine_settings` 経由の USI options に集約されている。
+ */
+export type AnalysisConfig =
+  | { mode: "infinite" }
+  | { mode: "time"; timeSeconds: number }
+  | { mode: "depth"; depth: number }
+  | { mode: "nodes"; nodes: number }
+  | { mode: "mate" };
 
-export interface AnalysisConfig {
-  mode: AnalysisMode;
-  time_limit?: Duration;
-  depth_limit?: number;
-  node_limit?: number;
-  /** legacy field — kept so旧 JSON のシリアライズが落ちないように。新規コードは mode を使う */
-  mate_search?: boolean;
-}
+export type AnalysisMode = AnalysisConfig["mode"];
 
 export interface AnalysisStatus {
   is_analyzing: boolean;

--- a/src/entities/engine/api/tauri.ts
+++ b/src/entities/engine/api/tauri.ts
@@ -63,20 +63,8 @@ export async function setPositionFromSfen(sfen: string): Promise<void> {
 }
 
 // ===== 解析実行 =====
-export async function startInfiniteAnalysis(): Promise<string> {
-  return await invoke("start_infinite_analysis");
-}
-
 export async function startAnalysis(config: AnalysisConfig): Promise<string> {
   return await invoke("start_analysis", { config });
-}
-
-export async function analyzeWithTime(timeSeconds: number): Promise<AnalysisResult> {
-  return await invoke("analyze_with_time", { timeSeconds });
-}
-
-export async function analyzeWithDepth(depth: number): Promise<AnalysisResult> {
-  return await invoke("analyze_with_depth", { depth });
 }
 
 export async function stopAnalysis(sessionId?: string): Promise<void> {

--- a/src/entities/engine/api/tauri.ts
+++ b/src/entities/engine/api/tauri.ts
@@ -1,5 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { AnalysisResult, AnalysisStatus, EngineInfo, EngineSettings } from "./rust-types";
+import type {
+  AnalysisConfig,
+  AnalysisResult,
+  AnalysisStatus,
+  EngineInfo,
+  EngineSettings,
+} from "./rust-types";
 
 // ===== エンジン初期化・管理 =====
 export async function initializeEngine(enginePath: string, workDir: string): Promise<void> {
@@ -59,6 +65,10 @@ export async function setPositionFromSfen(sfen: string): Promise<void> {
 // ===== 解析実行 =====
 export async function startInfiniteAnalysis(): Promise<string> {
   return await invoke("start_infinite_analysis");
+}
+
+export async function startAnalysis(config: AnalysisConfig): Promise<string> {
+  return await invoke("start_analysis", { config });
 }
 
 export async function analyzeWithTime(timeSeconds: number): Promise<AnalysisResult> {

--- a/src/features/settings/ui/engine-preset-dialog/EnginePresetEditDialogPanel.tsx
+++ b/src/features/settings/ui/engine-preset-dialog/EnginePresetEditDialogPanel.tsx
@@ -19,7 +19,11 @@ import ImportantOptionsSection from "./sections/ImportantOptionsSection";
 import AnalysisDefaultsSection from "./sections/AnalysisDefaultsSection";
 import PresetDialogFooter from "./PresetDialogFooter";
 import { useAppConfig } from "@/entities/app-config";
-import type { EnginePreset, PresetId } from "@/entities/engine-presets/model/types";
+import type {
+  AnalysisDefaults,
+  EnginePreset,
+  PresetId,
+} from "@/entities/engine-presets/model/types";
 import { useEnginePresets } from "@/entities/engine-presets/model/useEnginePresets";
 import { DEFAULT_USI_OPTIONS } from "@/entities/engine-presets/model/defaultOptions";
 import { filterEnginesByAiLabel, listAiLabels } from "../../lib/engineFilter";
@@ -431,25 +435,20 @@ function EnginePresetEditDialogInner({ presetId, open, onClose }: Props) {
       return;
     }
 
-    // analysis: <=0 は落とす（軽く）
-    const a = draft.analysis ?? { mateSearch: false };
+    // analysis: <=0 は落とす（軽く）。mode は preset 側に常に保持。
+    const a: AnalysisDefaults = draft.analysis ?? { mode: "infinite", mateSearch: false };
     const timeSeconds =
       a.timeSeconds != null ? clampInt(parseIntSafe(a.timeSeconds, 0), 0, 3600) : undefined;
     const depth = a.depth != null ? clampInt(parseIntSafe(a.depth, 0), 0, 999) : undefined;
     const nodes = a.nodes != null ? clampInt(parseIntSafe(a.nodes, 0), 0, 999_999_999) : undefined;
 
-    const analysis =
-      (timeSeconds && timeSeconds > 0) ||
-      (depth && depth > 0) ||
-      (nodes && nodes > 0) ||
-      a.mateSearch
-        ? {
-            timeSeconds: timeSeconds && timeSeconds > 0 ? timeSeconds : undefined,
-            depth: depth && depth > 0 ? depth : undefined,
-            nodes: nodes && nodes > 0 ? nodes : undefined,
-            mateSearch: Boolean(a.mateSearch),
-          }
-        : undefined;
+    const analysis: AnalysisDefaults = {
+      mode: a.mode,
+      timeSeconds: timeSeconds && timeSeconds > 0 ? timeSeconds : undefined,
+      depth: depth && depth > 0 ? depth : undefined,
+      nodes: nodes && nodes > 0 ? nodes : undefined,
+      mateSearch: a.mode === "mate",
+    };
 
     // options: 空は入れない + UI state 優先
     const rawOpt = draft.options ?? {};

--- a/src/features/settings/ui/engine-preset-dialog/EnginePresetEditDialogPanel.tsx
+++ b/src/features/settings/ui/engine-preset-dialog/EnginePresetEditDialogPanel.tsx
@@ -436,7 +436,7 @@ function EnginePresetEditDialogInner({ presetId, open, onClose }: Props) {
     }
 
     // analysis: <=0 は落とす（軽く）。mode は preset 側に常に保持。
-    const a: AnalysisDefaults = draft.analysis ?? { mode: "infinite", mateSearch: false };
+    const a: AnalysisDefaults = draft.analysis ?? { mode: "infinite" };
     const timeSeconds =
       a.timeSeconds != null ? clampInt(parseIntSafe(a.timeSeconds, 0), 0, 3600) : undefined;
     const depth = a.depth != null ? clampInt(parseIntSafe(a.depth, 0), 0, 999) : undefined;
@@ -447,7 +447,6 @@ function EnginePresetEditDialogInner({ presetId, open, onClose }: Props) {
       timeSeconds: timeSeconds && timeSeconds > 0 ? timeSeconds : undefined,
       depth: depth && depth > 0 ? depth : undefined,
       nodes: nodes && nodes > 0 ? nodes : undefined,
-      mateSearch: a.mode === "mate",
     };
 
     // options: 空は入れない + UI state 優先

--- a/src/features/settings/ui/engine-preset-dialog/sections/AnalysisDefaultsSection.tsx
+++ b/src/features/settings/ui/engine-preset-dialog/sections/AnalysisDefaultsSection.tsx
@@ -6,21 +6,19 @@ import type { EnginePreset, AnalysisDefaults } from "@/entities/engine-presets/m
 import type { AnalysisMode } from "@/entities/engine/api/rust-types";
 
 const MODE_OPTIONS: Array<{ value: AnalysisMode; label: string; description: string }> = [
-  { value: "infinite", label: "∞ 無限", description: "外部 Stop を待つまで思考し続ける" },
-  { value: "time", label: "時間", description: "byoyomi (ms) を engine に渡す" },
-  { value: "depth", label: "深さ", description: "rank1 が指定 depth に到達したら Stop" },
-  { value: "nodes", label: "ノード", description: "rank1 が指定 nodes に到達したら Stop" },
-  { value: "mate", label: "詰", description: "go mate / mate infinite を engine に渡す" },
+  { value: "infinite", label: "∞ 無限", description: "停止操作するまで思考し続ける" },
+  { value: "time", label: "時間", description: "指定した秒数で打ち切る" },
+  { value: "depth", label: "深さ", description: "最善手の読み深さが指定値に達したら打ち切る" },
+  { value: "nodes", label: "ノード", description: "探索ノード数が指定値に達したら打ち切る" },
+  { value: "mate", label: "詰", description: "詰み探索を行う" },
 ];
 
 function mergeAnalysis(
   prev: AnalysisDefaults | undefined,
   patch: Partial<AnalysisDefaults>,
 ): AnalysisDefaults {
-  const base: AnalysisDefaults = prev ?? { mode: "infinite", mateSearch: false };
-  const next: AnalysisDefaults = { ...base, ...patch };
-  next.mateSearch = next.mode === "mate";
-  return next;
+  const base: AnalysisDefaults = prev ?? { mode: "infinite" };
+  return { ...base, ...patch };
 }
 
 export default function AnalysisDefaultsSection(props: {
@@ -40,11 +38,11 @@ export default function AnalysisDefaultsSection(props: {
   return (
     <SSection
       title="解析デフォルト"
-      description="このプリセットで解析開始した時の go コマンドを決めます"
+      description="このプリセットで解析を開始したときの停止条件を決めます"
     >
       <SField
         label="モード"
-        description="go コマンドの形を決める。値は各モードのフィールドが保持します"
+        description="停止条件を選びます。各モード固有の値 (時間/深さ/ノード数) は下のフィールドで指定します"
       >
         <SRadioGroup
           name="analysis-mode"
@@ -103,27 +101,6 @@ export default function AnalysisDefaultsSection(props: {
           />
         </SField>
       </div>
-
-      <SField
-        label="Mate timeout (sec)"
-        description={
-          mode === "mate"
-            ? "0 / 空 で `go mate infinite`、それ以外は `go mate <ms>`"
-            : "保持のみ（Time フィールドを共有）"
-        }
-      >
-        <SInput
-          type="number"
-          min={0}
-          disabled={mode !== "mate"}
-          value={draft.analysis?.timeSeconds ?? ""}
-          onChange={(e) => {
-            const v = e.target.value;
-            const n = v === "" ? undefined : parseIntSafe(v, 0);
-            setAnalysis({ timeSeconds: n });
-          }}
-        />
-      </SField>
     </SSection>
   );
 }

--- a/src/features/settings/ui/engine-preset-dialog/sections/AnalysisDefaultsSection.tsx
+++ b/src/features/settings/ui/engine-preset-dialog/sections/AnalysisDefaultsSection.tsx
@@ -63,6 +63,8 @@ export default function AnalysisDefaultsSection(props: {
           <SInput
             type="number"
             min={0}
+            max={3600}
+            placeholder="未指定なら 30s"
             disabled={mode !== "time"}
             value={draft.analysis?.timeSeconds ?? ""}
             onChange={(e) => {
@@ -77,6 +79,8 @@ export default function AnalysisDefaultsSection(props: {
           <SInput
             type="number"
             min={0}
+            max={999}
+            placeholder="未指定なら 20"
             disabled={mode !== "depth"}
             value={draft.analysis?.depth ?? ""}
             onChange={(e) => {
@@ -91,6 +95,8 @@ export default function AnalysisDefaultsSection(props: {
           <SInput
             type="number"
             min={0}
+            max={999_999_999}
+            placeholder="未指定なら 100,000,000"
             disabled={mode !== "nodes"}
             value={draft.analysis?.nodes ?? ""}
             onChange={(e) => {

--- a/src/features/settings/ui/engine-preset-dialog/sections/AnalysisDefaultsSection.tsx
+++ b/src/features/settings/ui/engine-preset-dialog/sections/AnalysisDefaultsSection.tsx
@@ -1,97 +1,129 @@
 import type { Dispatch, SetStateAction } from "react";
 
-import { SField, SInput, SSection } from "../../kit";
+import { SField, SInput, SRadioGroup, SSection } from "../../kit";
 import { parseIntSafe } from "@/features/settings/lib/presetDialog";
-import type { EnginePreset } from "@/entities/engine-presets/model/types";
+import type { EnginePreset, AnalysisDefaults } from "@/entities/engine-presets/model/types";
+import type { AnalysisMode } from "@/entities/engine/api/rust-types";
+
+const MODE_OPTIONS: Array<{ value: AnalysisMode; label: string; description: string }> = [
+  { value: "infinite", label: "∞ 無限", description: "外部 Stop を待つまで思考し続ける" },
+  { value: "time", label: "時間", description: "byoyomi (ms) を engine に渡す" },
+  { value: "depth", label: "深さ", description: "rank1 が指定 depth に到達したら Stop" },
+  { value: "nodes", label: "ノード", description: "rank1 が指定 nodes に到達したら Stop" },
+  { value: "mate", label: "詰", description: "go mate / mate infinite を engine に渡す" },
+];
+
+function mergeAnalysis(
+  prev: AnalysisDefaults | undefined,
+  patch: Partial<AnalysisDefaults>,
+): AnalysisDefaults {
+  const base: AnalysisDefaults = prev ?? { mode: "infinite", mateSearch: false };
+  const next: AnalysisDefaults = { ...base, ...patch };
+  next.mateSearch = next.mode === "mate";
+  return next;
+}
 
 export default function AnalysisDefaultsSection(props: {
   draft: EnginePreset;
   setDraft: Dispatch<SetStateAction<EnginePreset | null>>;
 }) {
   const { draft, setDraft } = props;
+  const mode: AnalysisMode = draft.analysis?.mode ?? "infinite";
+
+  const setAnalysis = (patch: Partial<AnalysisDefaults>) => {
+    setDraft({
+      ...draft,
+      analysis: mergeAnalysis(draft.analysis, patch),
+    });
+  };
 
   return (
     <SSection
-      title="解析デフォルト（フロント保持）"
-      description="バックエンド非対応でもUI側で保持します"
+      title="解析デフォルト"
+      description="このプリセットで解析開始した時の go コマンドを決めます"
     >
+      <SField
+        label="モード"
+        description="go コマンドの形を決める。値は各モードのフィールドが保持します"
+      >
+        <SRadioGroup
+          name="analysis-mode"
+          layout="grid"
+          columns={5}
+          value={mode}
+          onChange={(v) => setAnalysis({ mode: v as AnalysisMode })}
+          options={MODE_OPTIONS.map((o) => ({
+            value: o.value,
+            label: o.label,
+            description: o.description,
+          }))}
+        />
+      </SField>
+
       <div className="presetDialog__grid3">
-        <SField label="Time (sec)" description="優先: 時間">
+        <SField label="Time (sec)" description={mode === "time" ? "アクティブ" : "保持のみ"}>
           <SInput
             type="number"
             min={0}
+            disabled={mode !== "time"}
             value={draft.analysis?.timeSeconds ?? ""}
             onChange={(e) => {
               const v = e.target.value;
               const n = v === "" ? undefined : parseIntSafe(v, 0);
-              setDraft({
-                ...draft,
-                analysis: {
-                  ...(draft.analysis ?? { mateSearch: false }),
-                  timeSeconds: n,
-                },
-              });
+              setAnalysis({ timeSeconds: n });
             }}
           />
         </SField>
 
-        <SField label="Depth" description="優先: 深さ">
+        <SField label="Depth" description={mode === "depth" ? "アクティブ" : "保持のみ"}>
           <SInput
             type="number"
             min={0}
+            disabled={mode !== "depth"}
             value={draft.analysis?.depth ?? ""}
             onChange={(e) => {
               const v = e.target.value;
               const n = v === "" ? undefined : parseIntSafe(v, 0);
-              setDraft({
-                ...draft,
-                analysis: {
-                  ...(draft.analysis ?? { mateSearch: false }),
-                  depth: n,
-                },
-              });
+              setAnalysis({ depth: n });
             }}
           />
         </SField>
 
-        <SField label="Nodes" description="優先: ノード数">
+        <SField label="Nodes" description={mode === "nodes" ? "アクティブ" : "保持のみ"}>
           <SInput
             type="number"
             min={0}
+            disabled={mode !== "nodes"}
             value={draft.analysis?.nodes ?? ""}
             onChange={(e) => {
               const v = e.target.value;
               const n = v === "" ? undefined : parseIntSafe(v, 0);
-              setDraft({
-                ...draft,
-                analysis: {
-                  ...(draft.analysis ?? { mateSearch: false }),
-                  nodes: n,
-                },
-              });
+              setAnalysis({ nodes: n });
             }}
           />
         </SField>
       </div>
 
-      <div className="presetDialog__row">
-        <label className="presetDialog__check">
-          <input
-            type="checkbox"
-            checked={Boolean(draft.analysis?.mateSearch)}
-            onChange={(e) => {
-              setDraft({
-                ...draft,
-                analysis: {
-                  ...(draft.analysis ?? { mateSearch: false }),
-                  mateSearch: e.target.checked,
-                },
-              });
-            }}
-          />
-          <span className="presetDialog__checkLabel">詰み探索（フロント保持）</span>
-        </label>
-      </div>
+      <SField
+        label="Mate timeout (sec)"
+        description={
+          mode === "mate"
+            ? "0 / 空 で `go mate infinite`、それ以外は `go mate <ms>`"
+            : "保持のみ（Time フィールドを共有）"
+        }
+      >
+        <SInput
+          type="number"
+          min={0}
+          disabled={mode !== "mate"}
+          value={draft.analysis?.timeSeconds ?? ""}
+          onChange={(e) => {
+            const v = e.target.value;
+            const n = v === "" ? undefined : parseIntSafe(v, 0);
+            setAnalysis({ timeSeconds: n });
+          }}
+        />
+      </SField>
     </SSection>
   );
 }

--- a/src/widgets/analysis-pane/ui/AnalysisPaneHeader.tsx
+++ b/src/widgets/analysis-pane/ui/AnalysisPaneHeader.tsx
@@ -7,7 +7,7 @@ import { useAnalysis } from "@/entities/analysis";
 import { useStudyPositions } from "@/entities/study-positions/model/useStudyPositions";
 
 function AnalysisPaneHeader() {
-  const { state, startInfiniteAnalysis, stopAnalysis } = useAnalysis();
+  const { state, startAnalysis, stopAnalysis } = useAnalysis();
   const { currentSfen } = usePositionSync();
   const { openModal, params, updateParams } = useURLParams();
   const { findBySfen } = useStudyPositions();
@@ -77,7 +77,7 @@ function AnalysisPaneHeader() {
       if (state.isAnalyzing) {
         await stopAnalysis();
       } else {
-        await startInfiniteAnalysis();
+        await startAnalysis();
       }
     } catch (error) {
       console.error("Failed to toggle analysis:", error);


### PR DESCRIPTION
Closes #107

## Summary
- Rust 側に `AnalysisMode` enum と `AnalysisConfig.mode` を追加し、`multi_pv` は削除（MultiPV は `apply_engine_settings` 経由に統一）
- `EngineAnalyzer::start_with_config(config)` を新設し、全モードで streaming（infinite / time / depth / nodes / mate）。depth/nodes は閾値到達で `Stop` を engine に送って bestmove で終了
- Tauri コマンド `start_analysis(config)` を追加して `lib.rs` に登録。`start_infinite_analysis` は互換のため残置
- Frontend: `AnalysisDefaults.mode` を必須化し、旧 JSON は `normalize.ts` で `mate>time>depth>nodes>infinite` の優先順で移行
- `AnalysisProvider` に `analysisDefaults` prop と `startAnalysis()` を追加。restart 経路も `start_analysis` 系に統一。`startInfiniteAnalysis` は alias に
- `AnalysisBridge` が `useEnginePresets().analysisDefaults` を注入
- 設定ダイアログの解析セクションを mode ラジオ駆動に書き換え

## Notes
- usi crate 0.6.2 は `go movetime` を `ThinkParams` で表現できないため、`time` モードは byoyomi で近似している。raw send 経路が追加され次第差し替える（コードにコメントあり）
- 旧フィールド `mateSearch` は `mode === \"mate\"` の派生として残し、ディスク上の後方互換のため `AnalysisDefaults` に保持
- `multi_pv` 関連 UI は別途 ImportantOptionsSection 側に存在（preset の USI options へ集約済み）

## Test plan
- [ ] preset で mode=infinite を選び、解析開始 → 従来通り無限解析が動く / Stop で止まる
- [ ] mode=time(10s) で開始 → engine が byoyomi 10s で終了 → bestmove で streaming 完了
- [ ] mode=depth(20) で開始 → rank1 の depth が 20 到達後に Stop → bestmove で終了
- [ ] mode=nodes(1,000,000) で開始 → rank1 の nodes が閾値到達後に Stop → bestmove で終了
- [ ] mode=mate で開始 → engine が `go mate` を受けて checkmate / bestmove を返す
- [ ] 解析中に preset を切り替えると、次の Play で新 mode が反映される
- [ ] 旧 preset JSON（`analysis.mode` なし）を読み込んで migration が透過に効く
- [x] `npm run lint && npm run build`
- [x] `cargo check` / `cargo clippy --all-targets -- -D warnings`