### PR TITLE
chore(deps): bump shogi-kifu-converter to v0.3.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4017,8 +4017,8 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shogi-kifu-converter"
-version = "0.2.2"
-source = "git+https://github.com/Rioh1118/shogi-kifu-converter-obsshogi.git?tag=v0.2.4#5b8a13112500b6ed0cef6fd139b8db750e23d541"
+version = "0.3.0"
+source = "git+https://github.com/Rioh1118/shogi-kifu-converter-obsshogi.git?tag=v0.3.1#83bf1388de14ed8ab8a759b4888e9bb59f446d4c"
 dependencies = [
  "csa",
  "encoding_rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.2.0", features = [] }
 
 [dependencies]
-shogi_kifu_converter_obsshogi = { git = "https://github.com/Rioh1118/shogi-kifu-converter-obsshogi.git", tag = "v0.2.4", package = "shogi-kifu-converter" }
+shogi_kifu_converter_obsshogi = { git = "https://github.com/Rioh1118/shogi-kifu-converter-obsshogi.git", tag = "v0.3.1", package = "shogi-kifu-converter" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"


### PR DESCRIPTION
## Summary
- `shogi-kifu-converter` を `v0.2.4` → `v0.3.1` に更新。
- v0.3.1 は `parse_kif_str` 内部で `relative` (左/右/上/...) 推論をスキップする最適化を入れた版（大型 KIF パースで ~99% を占めていた `display_single_move_kansuji` + `legality_lite` の合法手生成を排除）。
- obs-shogi の `src-tauri/src/search/kifu_reader.rs` 経由のインデックス構築が大幅高速化される見込み。

## 互換性
公開 API はシグネチャ完全互換のため、コード変更は `Cargo.toml` の 1 行のみ。

| 関数 | v0.3.1 での挙動 | obs-shogi への影響 |
|---|---|---|
| `parse_kif_str` / `parse_kif_file` | 内部で `normalize_with_options(true, false)` を呼び relative 推論をスキップ | 検索インデックス側（`position_apply` は `from`/`piece`/`to` しか読まない）→ 純粋に高速化 |
| `parse_ki2_str` / `parse_ki2_file` | 従来通り `normalize_with_color_correction(true)` (relative 維持) | 変化なし |
| `parse_csa_str` / `parse_jkf_str` | シグネチャ・挙動同じ | 変化なし |
| `JsonKifuFormat::normalize()` | `normalize_with_options(false, true)` のラッパ（relative 推論あり） | `src-tauri/src/kifu.rs` の write/convert/normalize コマンドは従来と完全同じ動作 |
| `to_kif_owned` / `to_ki2_owned` / `to_csa_owned` | シグネチャ・挙動同じ | 変化なし |

TS 側の `relative` 利用箇所（`formatMove` → `BranchCard`）は **tsshogi** が JKF を生成しており Rust クレートとは独立。影響なし。

## Test plan
- [x] `cargo check` green
- [x] `cargo build --release` green
- [x] `npm run build` (tsc + Vite) green
- [ ] `npm run tauri dev` で起動して KIF/KI2/CSA 棋譜の読み込み・保存・検索インデックス構築を手動確認
- [ ] 大型 KIF (14k+ 手) で `open_project` / `search_position` のインデックス構築が体感で速くなっていることを確認

## 参考
- upstream tag: https://github.com/Rioh1118/shogi-kifu-converter-obsshogi/releases/tag/v0.3.1
- commit: \`83bf1388de14ed8ab8a759b4888e9bb59f446d4c\`